### PR TITLE
Render Yoast tags in blog posts

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -12,7 +12,7 @@ const cwd = process.env.ELEVENTY_CWD
   : __dirname;
 
 const inputDir = path.relative(__dirname, path.join(cwd, 'src/content'));
-const wpInputDir = path.join(cwd, 'src/wp-content');
+const wpInputDir = path.relative(__dirname, path.join(cwd, 'src/wp-content'));
 const outputDir = path.join(cwd, 'build');
 const includeDirName = 'includes';
 

--- a/src/content/blog.njk
+++ b/src/content/blog.njk
@@ -1,5 +1,4 @@
 ---
-title: Blog
 layout: base.njk
 pagination:
   data: posts

--- a/src/content/index.njk
+++ b/src/content/index.njk
@@ -1,5 +1,4 @@
 ---
-title: Blog
 layout: base.njk
 ---
 

--- a/src/data/markup.js
+++ b/src/data/markup.js
@@ -1,0 +1,3 @@
+module.exports = {
+  siteTitle: 'Mozilla Add-ons Blog',
+};

--- a/src/filters.js
+++ b/src/filters.js
@@ -51,6 +51,15 @@ const makeBetterSafe = ({ markAsSafe }) => {
           if (node.getAttribute('type') !== 'application/ld+json') {
             node.remove();
           }
+
+          try {
+            // eslint-disable-next-line no-param-reassign
+            node.textContent = JSON.stringify(JSON.parse(node.textContent));
+          } catch (e) {
+            // Remove invalid content if it cannot be parsed as JSON.
+            // eslint-disable-next-line no-param-reassign
+            node.textContent = '';
+          }
         }
       });
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,16 +1,68 @@
 const createDOMPurify = require('dompurify');
 const { JSDOM } = require('jsdom');
 
+const ALLOWED_ATTRS_BY_TAG_FOR_HEAD_MARKUP = {
+  meta: ['name', 'content', 'property'],
+  link: ['rel', 'href'],
+  script: ['type'],
+};
+
 const makeBetterSafe = ({ markAsSafe }) => {
   const { window } = new JSDOM('');
   const DOMPurify = createDOMPurify(window);
 
-  return (value) => {
+  return (value, { isHeadMarkup = false } = {}) => {
     if (!value) {
-      return;
+      return undefined;
     }
 
-    // eslint-disable-next-line consistent-return
+    if (isHeadMarkup) {
+      const domPurifyOptions = {
+        WHOLE_DOCUMENT: true,
+        // This is needed because `WHOLE_DOCUMENT` is required to sanitize
+        // `meta` tags but DOMPurify will return the content inside
+        // `<html><head>...</head></html>` instead of "just" the meta tags.
+        RETURN_DOM: true,
+        // This is needed to allow property values like `og:xyz`.
+        ADD_URI_SAFE_ATTR: ['property'],
+        ALLOWED_TAGS: Object.keys(ALLOWED_ATTRS_BY_TAG_FOR_HEAD_MARKUP),
+        // We don't use `ALLOWED_ATTR` here because we want to allow different
+        // attributes for the different allowed tags.
+      };
+
+      // By default, all non-standard attributes will be removed by DOMPurify.
+      // This hook allows to mark some of these attributes as valid so that
+      // they are kept.
+      DOMPurify.addHook('uponSanitizeAttribute', (node, hookEvent) => {
+        const allowedAttributes =
+          ALLOWED_ATTRS_BY_TAG_FOR_HEAD_MARKUP[
+            (node.tagName || '').toLowerCase()
+          ] || [];
+
+        if (allowedAttributes.includes(hookEvent.attrName)) {
+          // eslint-disable-next-line no-param-reassign
+          hookEvent.forceKeepAttr = true;
+        }
+      });
+
+      // This hook sanitizes JSON+LD script tags.
+      DOMPurify.addHook('uponSanitizeElement', (node, hookEvent) => {
+        if (hookEvent.tagName === 'script') {
+          if (node.getAttribute('type') !== 'application/ld+json') {
+            node.remove();
+          }
+        }
+      });
+
+      const html = DOMPurify.sanitize(value.toString(), domPurifyOptions);
+
+      // Remove hooks when we don't need them anymore.
+      DOMPurify.removeHook('uponSanitizeAttribute');
+      DOMPurify.removeHook('uponSanitizeElement');
+
+      return markAsSafe(html.querySelector('head').innerHTML);
+    }
+
     return markAsSafe(DOMPurify.sanitize(value.toString()));
   };
 };

--- a/src/includes/head.njk
+++ b/src/includes/head.njk
@@ -2,22 +2,11 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ seo.title }}</title>
+  <title>{% if title %}{{ title }} - {% endif %}{{ markup.siteTitle }}</title>
 
-  <link rel="canonical" href="{{ seo.canonicalURL }}" />
-  <meta name="description" content="{{ seo.description }}" />
-
-  <meta property="og:description" content="{{ seo.description }}" />
-  <meta property="og:locale" content="en_US" />
-  <meta property="og:site_name" content="{{ site.title }}" />
-  <meta property="og:title" content="{{ title }}" />
-  <meta property="og:url" content="{{ seo.canonicalURL }}" />
-  <meta property="article:published_time" content="{{ fileDate.published }}" />
-
-  <script type="application/ld+json">{{ seo.jsonLD }}</script>
+  {{ blogpost.seoHead | safe({ isHeadMarkup: true }) }}
 
   <link rel="apple-touch-icon" href="{{ config.asset_path|safe }}/assets/img/favicon.png">
   <link rel="shortcut icon" href="{{ config.asset_path|safe }}/assets/img/favicon.ico">
   <link rel="stylesheet" href="{{ config.asset_path|safe }}/assets/css/styles.css">
 </head>
-

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -41,5 +41,99 @@ describe(__filename, () => {
       expect(betterSafe(null)).toEqual(undefined);
       expect(betterSafe('')).toEqual(undefined);
     });
+
+    it('removes meta tags by default', () => {
+      const markup =
+        '<meta content="summary_large_image" name="twitter:card" some="attr">';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup)).toEqual('');
+    });
+
+    it('allows meta tags when isHeadMarkup is true', () => {
+      const markup =
+        '<meta content="summary_large_image" name="twitter:card" some="attr">';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+        '<meta content="summary_large_image" name="twitter:card">'
+      );
+    });
+
+    it('accepts no tags when isHeadMarkup is true', () => {
+      const markup = '<!-- no content -->';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual('');
+    });
+
+    it('accepts property values starting with "og:"', () => {
+      const markup =
+        '<meta content="Mozilla Add-ons Blog" property="og:site_name">';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup, { isHeadMarkup: true })).toContain(
+        'property="og:site_name"'
+      );
+    });
+
+    it('allows link tags when isHeadMarkup is true', () => {
+      // The `content` attribute is only valid for `meta` tags so it should be
+      // removed on `link` tags.
+      const markup =
+        '<link rel="canonical" href="some-url" content="invalid" />';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+        '<link rel="canonical" href="some-url">'
+      );
+    });
+
+    it('allows json+ld scripts (only) when isHeadMarkup is true', () => {
+      const markup =
+        '<script type="application/ld+json">{"@context":"https://schema.org"}</script>';
+      const betterSafe = makeBetterSafe({
+        markAsSafe(content) {
+          return content;
+        },
+      });
+
+      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(markup);
+    });
+
+    it('disallows all other scripts when isHeadMarkup is true', () => {
+      for (const markup of [
+        '<script>{"@context":"https://schema.org"}</script>',
+        '<script type="module"></script>',
+      ]) {
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual('');
+      }
+    });
   });
 });

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -54,78 +54,23 @@ describe(__filename, () => {
       expect(betterSafe(markup)).toEqual('');
     });
 
-    it('allows meta tags when isHeadMarkup is true', () => {
-      const markup =
-        '<meta content="summary_large_image" name="twitter:card" some="attr">';
-      const betterSafe = makeBetterSafe({
-        markAsSafe(content) {
-          return content;
-        },
+    describe('isHeadMarkup = true', () => {
+      it('allows meta tags', () => {
+        const markup =
+          '<meta content="summary_large_image" name="twitter:card" some="attr">';
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+          '<meta content="summary_large_image" name="twitter:card">'
+        );
       });
 
-      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
-        '<meta content="summary_large_image" name="twitter:card">'
-      );
-    });
-
-    it('accepts no tags when isHeadMarkup is true', () => {
-      const markup = '<!-- no content -->';
-      const betterSafe = makeBetterSafe({
-        markAsSafe(content) {
-          return content;
-        },
-      });
-
-      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual('');
-    });
-
-    it('accepts property values starting with "og:"', () => {
-      const markup =
-        '<meta content="Mozilla Add-ons Blog" property="og:site_name">';
-      const betterSafe = makeBetterSafe({
-        markAsSafe(content) {
-          return content;
-        },
-      });
-
-      expect(betterSafe(markup, { isHeadMarkup: true })).toContain(
-        'property="og:site_name"'
-      );
-    });
-
-    it('allows link tags when isHeadMarkup is true', () => {
-      // The `content` attribute is only valid for `meta` tags so it should be
-      // removed on `link` tags.
-      const markup =
-        '<link rel="canonical" href="some-url" content="invalid" />';
-      const betterSafe = makeBetterSafe({
-        markAsSafe(content) {
-          return content;
-        },
-      });
-
-      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
-        '<link rel="canonical" href="some-url">'
-      );
-    });
-
-    it('allows json+ld scripts (only) when isHeadMarkup is true', () => {
-      const markup =
-        '<script type="application/ld+json">{"@context":"https://schema.org"}</script>';
-      const betterSafe = makeBetterSafe({
-        markAsSafe(content) {
-          return content;
-        },
-      });
-
-      expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(markup);
-    });
-
-    it('disallows all other scripts when isHeadMarkup is true', () => {
-      for (const markup of [
-        '<script>{"@context":"https://schema.org"}</script>',
-        '<script type="module"></script>',
-      ]) {
+      it('accepts no tags', () => {
+        const markup = '<!-- no content -->';
         const betterSafe = makeBetterSafe({
           markAsSafe(content) {
             return content;
@@ -133,7 +78,107 @@ describe(__filename, () => {
         });
 
         expect(betterSafe(markup, { isHeadMarkup: true })).toEqual('');
-      }
+      });
+
+      it('accepts property values starting with "og:"', () => {
+        const markup =
+          '<meta content="Mozilla Add-ons Blog" property="og:site_name">';
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toContain(
+          'property="og:site_name"'
+        );
+      });
+
+      it('sanitizes the value of the "content" attribute', () => {
+        const badContent = '\\"><script>alert(1)</script><meta name=foo';
+        const markup = `<meta content="${badContent}" property="og:site_name">`;
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+          '<meta content="\\"><meta name="foo&quot;" property="og:site_name">'
+        );
+      });
+
+      it('sanitizes the value of the "property" attribute', () => {
+        const badContent = 'og:\\"><script>alert(1)</script><meta';
+        const markup = `<meta property="${badContent}" name="foo">`;
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+          '<meta property="og:\\">'
+        );
+      });
+      it('allows link tags', () => {
+        // The `content` attribute is only valid for `meta` tags so it should be
+        // removed on `link` tags.
+        const markup =
+          '<link rel="canonical" href="some-url" content="invalid" />';
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+          '<link rel="canonical" href="some-url">'
+        );
+      });
+
+      it('allows json+ld scripts (only)', () => {
+        const markup =
+          '<script type="application/ld+json">{"@context":"https://schema.org"}</script>';
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(markup);
+      });
+
+      it('handles two type attributes for a script tag', () => {
+        const markup =
+          '<script type="application/ld+json" type="text/javascript">alert("oops 1")</script>';
+
+        const betterSafe = makeBetterSafe({
+          markAsSafe(content) {
+            return content;
+          },
+        });
+
+        expect(betterSafe(markup, { isHeadMarkup: true })).toEqual(
+          '<script type="application/ld+json"></script>'
+        );
+      });
+
+      it('disallows all other scripts', () => {
+        for (const markup of [
+          '<script>{"@context":"https://schema.org"}</script>',
+          '<script type="module"></script>',
+          '<script type="text/javascript" type="application/ld+json">alert("oops 2")</script>',
+        ]) {
+          const betterSafe = makeBetterSafe({
+            markAsSafe(content) {
+              return content;
+            },
+          });
+
+          expect(betterSafe(markup, { isHeadMarkup: true })).toEqual('');
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
fixes https://github.com/mozilla/addons-blog/issues/10

---

- [x] support `meta` tags
- [x] support `link` tags (canonical)
- [x] support json+ld