### PR TITLE
Do not override safe fiter when building the WP theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
       - run: yarn build:wptheme
       - run: yarn lint:php
       - run: test -f wptheme.zip
+      - run: grep "get_template_directory_uri" build/single.php
 
   blog:
     docker:

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -30,8 +30,12 @@ module.exports = function configure(eleventyConfig) {
 
   eleventyConfig.setLibrary('njk', nunjucksEnvironment);
 
-  // Override the default `safe` Nunjucks filter to run DOMPurify.
-  eleventyConfig.addNunjucksFilter('safe', makeBetterSafe({ markAsSafe }));
+  // For the WordPress theme, we don't want to override the `safe` filter
+  // because we output PHP code that would get removed by DOMPurify otherwise.
+  if (!buildWordpressTheme) {
+    // Override the default `safe` Nunjucks filter to run DOMPurify.
+    eleventyConfig.addNunjucksFilter('safe', makeBetterSafe({ markAsSafe }));
+  }
 
   eleventyConfig.addFilter('luxon', (value, format) => {
     return DateTime.fromISO(value).toFormat(format);
@@ -73,13 +77,13 @@ module.exports = function configure(eleventyConfig) {
     return getPost(allPosts, currentPost, 1);
   });
 
+  // We have integration tests that rely on a test project and it doesn't have
+  // the files listed below so we don't copy those when executing the tests.
   if (process.env.NODE_ENV !== 'test') {
     // Explicitly copy through the built files needed.
     eleventyConfig.addPassthroughCopy({
       './src/content/robots.txt': 'robots.txt',
-    });
-    eleventyConfig.addPassthroughCopy({ './src/assets/img/': 'assets/img/' });
-    eleventyConfig.addPassthroughCopy({
+      './src/assets/img/': 'assets/img/',
       './src/assets/fonts/': 'assets/fonts/',
     });
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/41

---

After #22, building the WP theme removes the PHP code that is used to output the template directory URIs. This patch fixes it and adds a test to avoid regressions in the future.