### PR TITLE
Enable support for post thumbnails in WP theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 npm-debug.log*
 coverage
 .coverage
+.phpunit.result.cache
 
 node_modules
 /vendor/

--- a/src/wp-content/functions.njk
+++ b/src/wp-content/functions.njk
@@ -1,0 +1,12 @@
+---
+permalink: functions.php
+---
+<?php
+
+if (!function_exists('addonsblog_theme_setup')) {
+  function addonsblog_theme_setup() {
+    add_theme_support('post-thumbnails', ['post']);
+  }
+}
+
+add_action('after_setup_theme', 'addonsblog_theme_setup');

--- a/tests/php/WordPressThemeTest.php
+++ b/tests/php/WordPressThemeTest.php
@@ -44,6 +44,31 @@ final class WordPressThemeTest extends DOMTestCase
         );
     }
 
+    public function testFunctions(): void
+    {
+        function add_theme_support($featureName, $options)
+        {
+            if ($featureName !== 'post-thumbnails') {
+                throw new \InvalidArgumentException('invalid feature name');
+            }
+
+            if ($options !== ['post']) {
+                throw new \InvalidArgumentException(
+                    'invalid options for "post-thumbnails"'
+                );
+            }
+        }
+
+        function add_action($hookName, $funcName)
+        {
+            $funcName();
+        }
+
+        require __DIR__ . '/../../build/functions.php';
+
+        $this->expectNotToPerformAssertions();
+    }
+
     private function render($template, $posts = 0): string
     {
         global $nb_posts;


### PR DESCRIPTION
refs #8 

---

In order to be able to set featured images, we need to tell WP that the theme
supports featured images.