### PR TITLE
Refactor header a bit

### DIFF
--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -1,19 +1,21 @@
-.Header {
+.header {
+  background-color: #20123a;
+  background-repeat: no-repeat;
+  background-size: cover;
   min-height: 80vh;
-  padding: 1em;
 }
 
-.Header h1 {
-  color: white;
-  font-size: 45px;
-  line-height: 1.2;
-  margin-top: 30vh;
-  text-align: center;
-  text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
-  text-transform: uppercase;
+.header-overlay {
+  background-color: transparentize(#000, 0.5);
+  height: 100%;
 }
 
-.Header-title {
+.header-wrapper {
+  height: 100%;
+  padding-top: 44px;
+}
+
+.header-logo {
   // This is width / height of the source SVG.
   $aspectRatio: 4.3125;
   $smallHeight: 48px;
@@ -29,6 +31,29 @@
   background-size: $smallWidth $smallHeight;
   display: block;
   height: $smallHeight;
-  margin: 0;
-  width: 100%;
+  margin: 20px auto;
+  width: $smallWidth;
+
+  @include respond-to(l) {
+    margin-left: 48px;
+    margin-top: 0;
+  }
+}
+
+.header-title {
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  font-size: 44px;
+  height: 60vh;
+  justify-content: center;
+  line-height: 1.2;
+  margin: 0 auto;
+  text-align: center;
+  text-transform: uppercase;
+  width: 70%;
+
+  @include respond-to(l) {
+    font-size: 64px;
+  }
 }

--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -8,6 +8,10 @@
 .header-overlay {
   background-color: transparentize(#000, 0.5);
   height: 100%;
+
+  .header--no-featured-image & {
+    background-color: transparent;
+  }
 }
 
 .header-wrapper {

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -22,6 +22,10 @@
   width: 1px;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 html,
 body {
   height: 100%;

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -20,7 +20,11 @@
     {%- endblock %}
   </head>
   <body>
+    {% if featuredImage %}
     <header class="header" style="background-image: url('{{ featuredImage }}');">
+    {% else %}
+    <header class="header header--no-featured-image">
+    {% endif %}
       <div class="header-overlay">
         <div class="header-wrapper">
           <a class="header-logo" href="/">

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -20,14 +20,18 @@
     {%- endblock %}
   </head>
   <body>
-    <header
-      class="Header"
-      style="background: #20123a url('{{ featuredImage }}') no-repeat center;">
-      <a class="Header-title" href="/">
-        <span class="visually-hidden">Firefox Browser Add-ons</span>
-      </a>
+    <header class="header" style="background-image: url('{{ featuredImage }}');">
+      <div class="header-overlay">
+        <div class="header-wrapper">
+          <a class="header-logo" href="/">
+            <span class="visually-hidden">Firefox Browser Add-ons</span>
+          </a>
 
-      <h1>{% if title %}{{ title }}{% else %}{{ markup.siteTitle }}{% endif %}</h1>
+          <h1 class="header-title">
+            {% if title %}{{ title }}{% else %}{{ markup.siteTitle }}{% endif %}
+          </h1>
+        </div>
+      </div>
     </header>
 
     {% block content %}

--- a/tests/php/WordPressThemeTest.php
+++ b/tests/php/WordPressThemeTest.php
@@ -30,7 +30,7 @@ final class WordPressThemeTest extends DOMTestCase
             $html
         );
         $this->assertStringContainsString(
-            "url('thumbnail.jpg') no-repeat",
+            "background-image: url('thumbnail.jpg');",
             $html
         );
         $this->assertSelectEquals('.Content-wrapper', 'some content', 1, $html);


### PR DESCRIPTION
fixes #71 

---

So.. I fixed the header to have something very close to the current mocks. I know we'd like to avoid inline styles, but I don't really know how to do that with an image tag. See: https://github.com/mozilla/addons-blog/issues/79 for that particular problem.


## Screenshots

![Screen Shot 2021-04-02 at 10 26 48](https://user-images.githubusercontent.com/217628/113265926-f705b300-92d4-11eb-8622-6336ab664a6e.png)

Super large screen:

![Screen Shot 2021-04-02 at 10 27 43](https://user-images.githubusercontent.com/217628/113265948-fb31d080-92d4-11eb-87a2-1ee64e33fe73.png)

Mobile:

![Screen Shot 2021-04-02 at 10 27 39](https://user-images.githubusercontent.com/217628/113265943-fa993a00-92d4-11eb-935f-c24b1ae2a3c5.png)