### PR TITLE
Deploy blog on -dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,10 @@ jobs:
           name: addons-blog deployment (dev)
           command: |
             pwd && ls -l
-            AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"            \
-            AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"    \
-            ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"          \
-            ADDONS_BLOG_BUCKET_PREFIX="${ADDONS_BLOG_BUCKET_PREFIX}"\
+            AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"              \
+            AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"      \
+            ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"            \
+            ADDONS_BLOG_BUCKET_PREFIX="${ADDONS_BLOG_BUCKET_PREFIX}"  \
             ./bin/deploy.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - *attach_deploy_workspace
       - *install_aws_cli
       - run:
-          name: addons-blog deployment (unpublished)
+          name: addons-blog deployment (dev)
           command: |
             pwd && ls -l
             AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"          \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,10 @@ jobs:
           name: addons-blog deployment (dev)
           command: |
             pwd && ls -l
-            AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"          \
-            AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"  \
-            ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"        \
+            AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"            \
+            AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"    \
+            ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"          \
+            ADDONS_BLOG_BUCKET_PREFIX="${ADDONS_BLOG_BUCKET_PREFIX}"\
             ./bin/deploy.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,6 @@ workflows:
     jobs:
       - wptheme
       - blog
-      - deploy-unpublished:
+      - deploy-dev:
           requires:
             - blog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
             bin/asset-pipeline
       - *persist_build_workspace
 
-  deploy-unpublished:
+  deploy-dev:
     <<: *deployment_container
     steps:
       - *attach_deploy_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,6 @@ workflows:
     jobs:
       - wptheme
       - blog
-      - deploy-unpublished
+      - deploy-unpublished:
           requires:
             - blog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
       - run:
           name: addons-blog deployment (unpublished)
           command: |
+            pwd && ls -l
             AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"          \
             AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"  \
             ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"        \
@@ -92,3 +93,5 @@ workflows:
       - wptheme
       - blog
       - deploy-unpublished
+          requires:
+            - blog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,12 @@ references:
         sudo pip install --upgrade pip
         sudo pip install --upgrade awscli
 
+  persist_build_workspace: &persist_build_workspace
+    persist_to_workspace:
+      root: ./
+      paths:
+        - ./*
+
   restore_build_cache: &restore_build_cache
     restore_cache:
       name: restore yarn package cache
@@ -71,6 +77,7 @@ jobs:
             yarn sass:build
             yarn script:build
             bin/asset-pipeline
+      - *persist_build_workspace
 
   deploy-unpublished:
     <<: *deployment_container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,12 @@ workflows:
       - build-blog:
           requires:
             - test-blog
+          filters:
+            branches:
+              only: main
       - deploy-dev:
           requires:
             - build-blog
+          filters:
+            branches:
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,21 @@
 version: 2.1
 
 references:
+  attach_deploy_workspace: &attach_deploy_workspace
+    attach_workspace:
+      at: .
+
+  deployment_container: &deployment_container
+    docker:
+      - image: circleci/python:3.9-node
+
+  install_aws_cli: &install_aws_cli
+    run:
+      name: Install AWS CLI
+      command: |
+        sudo pip install --upgrade pip
+        sudo pip install --upgrade awscli
+
   restore_build_cache: &restore_build_cache
     restore_cache:
       name: restore yarn package cache
@@ -57,9 +72,23 @@ jobs:
             yarn script:build
             bin/asset-pipeline
 
+  deploy-unpublished:
+    <<: *deployment_container
+    steps:
+      - *attach_deploy_workspace
+      - *install_aws_cli
+      - run:
+          name: addons-blog deployment (unpublished)
+          command: |
+            AWS_ACCESS_KEY_ID="${DEV_AWS_ACCESS_KEY_ID}"          \
+            AWS_SECRET_ACCESS_KEY="${DEV_AWS_SECRET_ACCESS_KEY}"  \
+            ADDONS_BLOG_BUCKET="${DEV_ADDONS_BLOG_BUCKET}"        \
+            ./bin/deploy.sh
+
 workflows:
   version: 2
   default-workflow:
     jobs:
       - wptheme
       - blog
+      - deploy-unpublished

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ references:
     docker:
       - image: circleci/python:3.9-node
 
+  node_prod_container: &node_prod_container
+    docker:
+      - image: circleci/node:12
+
   install_aws_cli: &install_aws_cli
     run:
       name: Install AWS CLI
@@ -42,7 +46,7 @@ references:
         - ~/.cache/yarn
 
 jobs:
-  wptheme:
+  test-wptheme:
     docker:
       - image: cimg/php:7.4-node
     steps:
@@ -59,9 +63,8 @@ jobs:
             ./vendor/bin/phpunit
       - run: test -f wptheme.zip
 
-  blog:
-    docker:
-      - image: circleci/node:12
+  test-blog:
+    <<: *node_prod_container
     steps:
       - checkout
       - *restore_build_cache
@@ -77,6 +80,15 @@ jobs:
             yarn sass:build
             yarn script:build
             bin/asset-pipeline
+
+  build-blog:
+    <<: *node_prod_container
+    steps:
+      - checkout
+      - *restore_build_cache
+      - *run_yarn_install
+      - *save_build_cache
+      - run: yarn build:production
       - *persist_build_workspace
 
   deploy-dev:
@@ -98,8 +110,11 @@ workflows:
   version: 2
   default-workflow:
     jobs:
-      - wptheme
-      - blog
+      - test-wptheme
+      - test-blog
+      - build-blog:
+          requires:
+            - test-blog
       - deploy-dev:
           requires:
-            - blog
+            - build-blog

--- a/bin/build-version-json.sh
+++ b/bin/build-version-json.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "$(dirname $0)"
+cd $(dirname $0)/..
+
+HASH=$(git --no-pager log --format=format:"%H" -1)
+TAG=$(git describe --tags)
+
+printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/extension-workshop"}\n' \
+    "$HASH" \
+    "$TAG" \
+    > version.json
+
+cat version.json

--- a/bin/build-version-json.sh
+++ b/bin/build-version-json.sh
@@ -6,7 +6,7 @@ cd $(dirname $0)/..
 HASH=$(git --no-pager log --format=format:"%H" -1)
 TAG=$(git describe --tags)
 
-printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/extension-workshop"}\n' \
+printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/addons-blog"}\n' \
     "$HASH" \
     "$TAG" \
     > version.json

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,6 +17,10 @@ if [ -z "$ADDONS_BLOG_BUCKET" ]; then
     exit 1
 fi
 
+if [ -n "$ADDONS_BLOG_BUCKET_PREFIX" ]; then
+    ADDONS_BLOG_BUCKET="$ADDONS_BLOG_BUCKET/$ADDONS_BLOG_BUCKET_PREFIX"
+fi
+
 # The basic strategy is to sync all the files that need special attention
 # first, and then sync everything else which will get defaults
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -79,7 +79,7 @@ aws s3 sync \
   --metadata "{${CSP}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
-  dist/ s3://${ADDONS_BLOG_BUCKET}/
+  dist/blog/ s3://${ADDONS_BLOG_BUCKET}/
 
 # JSON; short cache
 aws s3 sync \
@@ -90,7 +90,7 @@ aws s3 sync \
   --metadata "{${ACAO}, ${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
-  dist/ s3://${ADDONS_BLOG_BUCKET}/
+  dist/blog/ s3://${ADDONS_BLOG_BUCKET}/
 
 # SVG; cache forever, assign correct content-type
 aws s3 sync \
@@ -101,7 +101,7 @@ aws s3 sync \
   --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
-  dist/ s3://${ADDONS_BLOG_BUCKET}/
+  dist/blog/ s3://${ADDONS_BLOG_BUCKET}/
 
 # Everything else; cache forever, because it has hashes in the filenames
 aws s3 sync \
@@ -110,11 +110,11 @@ aws s3 sync \
   --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
-  dist/ s3://${ADDONS_BLOG_BUCKET}/
+  dist/blog/ s3://${ADDONS_BLOG_BUCKET}/
 
 # HTML - `path/index.html` to `path` resources; short cache
-for fn in $(find dist -name 'index.html' -not -path 'dist/index.html'); do
-  s3path=${fn#dist/}
+for fn in $(find dist/blog -name 'index.html' -not -path 'dist/blog/index.html'); do
+  s3path=${fn#dist/blog/}
   s3path=${s3path%/index.html}
   aws s3 cp \
     --cache-control "max-age=${TEN_MINUTES}" \

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -123,7 +123,7 @@ for fn in $(find dist/blog -name 'index.html' -not -path 'dist/blog/index.html')
     --include "*.html" \
     --metadata "{${CSP}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
     --metadata-directive "REPLACE" \
-    --website-redirect "/${s3path}/" \
+    --website-redirect "/blog/${s3path}/" \
     --acl "public-read" \
     $fn s3://${ADDONS_BLOG_BUCKET}/${s3path}
 done

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -35,14 +35,13 @@ CSPSTATIC="\"content-security-policy\": \"default-src 'none'; "\
 # DO NOT REMOVE the locale from the newsletter form url. See #476.
 CSP="\"content-security-policy\": \"default-src 'none'; "\
 "base-uri 'self'; "\
-"connect-src 'self' https://blog.mozilla.org/addons/feed/ https://www.mozilla.org/en-US/newsletter/ https://www.google-analytics.com/; "\
+"connect-src 'self' https://www.google-analytics.com/; "\
 "font-src 'self'; "\
-"form-action 'self' https://www.mozilla.org/en-US/newsletter/; "\
+"form-action 'none'; "\
 "frame-ancestors 'none'; "\
-"frame-src https://www.youtube.com/embed/; "\
-"img-src 'self' data:; "\
+"img-src 'self'; "\
 "object-src 'none'; "\
-"script-src 'self' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/ 'sha256-cEol3PeVsUqXLYFr6jKFJdNafMQx9RDvCSi6+kCHa6U=' https://www.google-analytics.com/analytics.js; "\
+"script-src 'self' https://www.google-analytics.com/analytics.js; "\
 "style-src 'self' 'unsafe-inline'\""
 HSTS="\"strict-transport-security\": \"max-age=${ONE_YEAR}; includeSubDomains; preload\""
 TYPE="\"x-content-type-options\": \"nosniff\""
@@ -124,4 +123,3 @@ for fn in $(find dist -name 'index.html' -not -path 'dist/index.html'); do
     --acl "public-read" \
     $fn s3://${ADDONS_BLOG_BUCKET}/${s3path}
 done
-

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# This file is used to deploy addons-blog to an S3 bucket.
+# You need to set the S3 bucket name in an environment variable named
+# ADDONS_BLOG_BUCKET.
+
+set -ex
+
+if [ ! -d "dist" ]; then
+    echo "Can't find /dist/ directory. Are you running from the correct"\
+         "root directory?"
+    exit 1
+fi
+
+if [ -z "$ADDONS_BLOG_BUCKET" ]; then
+    echo "The S3 bucket is not set. Failing."
+    exit 1
+fi
+
+# The basic strategy is to sync all the files that need special attention
+# first, and then sync everything else which will get defaults
+
+
+# For short-lived assets; in seconds
+TEN_MINUTES="600"
+
+# For long-lived assets; in seconds
+ONE_YEAR="31536000"
+
+CSPSTATIC="\"content-security-policy\": \"default-src 'none'; "\
+"base-uri 'none'; "\
+"form-action 'none'; "\
+"object-src 'none'\""
+
+# DO NOT REMOVE the locale from the newsletter form url. See #476.
+CSP="\"content-security-policy\": \"default-src 'none'; "\
+"base-uri 'self'; "\
+"connect-src 'self' https://blog.mozilla.org/addons/feed/ https://www.mozilla.org/en-US/newsletter/ https://www.google-analytics.com/; "\
+"font-src 'self'; "\
+"form-action 'self' https://www.mozilla.org/en-US/newsletter/; "\
+"frame-ancestors 'none'; "\
+"frame-src https://www.youtube.com/embed/; "\
+"img-src 'self' data:; "\
+"object-src 'none'; "\
+"script-src 'self' https://www.youtube.com/iframe_api https://www.youtube.com/s/player/ 'sha256-cEol3PeVsUqXLYFr6jKFJdNafMQx9RDvCSi6+kCHa6U=' https://www.google-analytics.com/analytics.js; "\
+"style-src 'self' 'unsafe-inline'\""
+HSTS="\"strict-transport-security\": \"max-age=${ONE_YEAR}; includeSubDomains; preload\""
+TYPE="\"x-content-type-options\": \"nosniff\""
+XSS="\"x-xss-protection\": \"1; mode=block\""
+XFRAME="\"x-frame-options\": \"SAMEORIGIN\""
+REFERRER="\"referrer-policy\": \"no-referrer-when-downgrade\""
+ACAO="\"Access-Control-Allow-Origin\": \"*\""
+
+
+# build version.json if it isn't provided
+[ -e version.json ] || $(dirname $0)/build-version-json.sh
+
+if [ -e version.json ]; then
+    mv version.json dist/__version__
+    # __version__ JSON; short cache
+    aws s3 cp \
+      --cache-control "max-age=${TEN_MINUTES}" \
+      --content-type "application/json" \
+      --metadata "{${ACAO}, ${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+      --metadata-directive "REPLACE" \
+      --acl "public-read" \
+      dist/__version__ s3://${ADDONS_BLOG_BUCKET}/__version__
+fi
+
+# HTML; short cache
+aws s3 sync \
+  --cache-control "max-age=${TEN_MINUTES}" \
+  --content-type "text/html" \
+  --exclude "*" \
+  --include "*.html" \
+  --metadata "{${CSP}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${ADDONS_BLOG_BUCKET}/
+
+# JSON; short cache
+aws s3 sync \
+  --cache-control "max-age=${TEN_MINUTES}" \
+  --content-type "application/json" \
+  --exclude "*" \
+  --include "*.json" \
+  --metadata "{${ACAO}, ${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${ADDONS_BLOG_BUCKET}/
+
+# SVG; cache forever, assign correct content-type
+aws s3 sync \
+  --cache-control "max-age=${ONE_YEAR}, immutable" \
+  --content-type "image/svg+xml" \
+  --exclude "*" \
+  --include "*.svg" \
+  --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${ADDONS_BLOG_BUCKET}/
+
+# Everything else; cache forever, because it has hashes in the filenames
+aws s3 sync \
+  --delete \
+  --cache-control "max-age=${ONE_YEAR}, immutable" \
+  --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${ADDONS_BLOG_BUCKET}/
+
+# HTML - `path/index.html` to `path` resources; short cache
+for fn in $(find dist -name 'index.html' -not -path 'dist/index.html'); do
+  s3path=${fn#dist/}
+  s3path=${s3path%/index.html}
+  aws s3 cp \
+    --cache-control "max-age=${TEN_MINUTES}" \
+    --content-type "text/html" \
+    --exclude "*" \
+    --include "*.html" \
+    --metadata "{${CSP}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+    --metadata-directive "REPLACE" \
+    --website-redirect "/${s3path}/" \
+    --acl "public-read" \
+    $fn s3://${ADDONS_BLOG_BUCKET}/${s3path}
+done
+

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean-tests": "rimraf './tests/fixtures/dist/**/*!(.gitkeep)'",
     "build": "npm run clean && eleventy --config=./eleventy.config.js && npm run sass:build && npm run script:build",
     "build:debug": "DEBUG=Eleventy* npm run build:serve",
-    "build:production": "ELEVENTY_ENV=production npm run build && bin/asset-pipeline",
+    "build:production": "rimraf './dist/' && ELEVENTY_ENV=production npm run build && bin/asset-pipeline",
     "build:serve": "eleventy --serve --port 8081 --config=./eleventy.config.js",
     "build:wptheme": "BUILD_WORDPRESS_THEME='1' npm run build && cd build/ && zip -r ../wptheme.zip .",
     "start": "npm run clean && DONT_FIX_INTERNAL_URLS='1' npm-run-all -p build:serve sass:* script:*",


### PR DESCRIPTION
A few notes about this PR:

1. This PR mimics how we deploy https://github.com/mozilla/extension-workshop.

2. The `deploy.sh` script assumes that all built assets are located in `dist/` directory. If this is incorrect, then we can adjust that.
3. The files that `deploy.sh` script tries to upload may need change too.
4. The CSP and other headers in `deploy.sh` may need to be adjusted to suit the need of this project.

5. This PR only deals with deploying -dev environment. If we were to follow the example of extension-workshop project, we would need to use the tags to give a hint as to which env we want to deploy, e.g. `v1.0.0-stage` is deployed to -stage and `v1.0.0` is deployed to -prod. See [[1]](https://github.com/mozilla/extension-workshop/blob/d04c3d4ca9f687de45a5bf3a05e3217bb4d7d306/.circleci/config.yml#L112-L132) for reference.