### PR TITLE
Refactor blogpost nav (fix minor UI glitch, make it work in WP)

### DIFF
--- a/src/assets/css/blogpost-nav.scss
+++ b/src/assets/css/blogpost-nav.scss
@@ -1,4 +1,4 @@
-.prev-next {
+.blogpost-nav {
   width: 100%;
   background: #eee;
 
@@ -21,36 +21,41 @@
         text-decoration: underline;
       }
 
-      .arrow-right {
+      .blogpost-nav-arrow-right {
         right: 0;
       }
 
-      .arrow-left {
+      .blogpost-nav-arrow-left {
         left: 0;
       }
     }
   }
 
   li {
+    box-sizing: border-box;
+    float: left;
     list-style-type: none;
     width: 50%;
-    float: left;
-    box-sizing: border-box;
 
     &:last-of-type {
       box-shadow: -1px 0 0 0 #ccc;
     }
 
-    &.next:last-of-type:first-of-type {
+    &.blogpost-nav-next:last-of-type:first-of-type {
       float: right;
     }
 
-    &.next {
+    &.blogpost-nav-next {
       padding: 0 3em 0 1em;
     }
 
-    &.prev {
+    &.blogpost-nav-prev {
       padding: 0 1em 0 3em;
+    }
+
+    &.blogpost-nav-no-prev,
+    &.blogpost-nav-no-next {
+      box-shadow: none;
     }
   }
 
@@ -65,25 +70,23 @@
     font-size: 16px;
     font-weight: 600;
   }
+}
 
-  .arrow-left,
-  .arrow-right {
-    width: 30px;
-    height: 50px;
-    position: absolute;
-    top: 50%;
-    margin-top: -25px;
-    -webkit-transition: left 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5),
-      right 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5);
-    transition: left 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5),
-      right 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5);
-  }
+.blogpost-nav-arrow-left,
+.blogpost-nav-arrow-right {
+  width: 30px;
+  height: 50px;
+  position: absolute;
+  top: 50%;
+  margin-top: -25px;
+  transition: left 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5),
+    right 250ms cubic-bezier(0.3, -0.5, 0.6, 1.5);
+}
 
-  .arrow-left {
-    left: 10px;
-  }
+.blogpost-nav-arrow-left {
+  left: 10px;
+}
 
-  .arrow-right {
-    right: 10px;
-  }
+.blogpost-nav-arrow-right {
+  right: 10px;
 }

--- a/src/assets/css/blogposts.scss
+++ b/src/assets/css/blogposts.scss
@@ -1,3 +1,5 @@
+@import './blogpost-nav';
+
 $pull-quote-color: #4e1a6a;
 
 .blogpost {

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -5,7 +5,6 @@
 @import '../fonts/inter.scss';
 @import './inc/variables';
 @import './inc/mixins';
-@import './inc/prev-next-nav';
 
 @import './header';
 @import './blogposts';

--- a/src/content/blogposts.njk
+++ b/src/content/blogposts.njk
@@ -11,8 +11,6 @@ permalink: "{{ blogpost.permalink }}index.html"
 {% set title = blogpost.title %}
 {% set featuredImage = media | mediaGetFullURL(blogpost.featuredImage) %}
 {% set author = authors | getAuthor(blogpost.author) %}
-{% set prevPost = posts | getPrevPost(blogpost) %}
-{% set nextPost = posts | getNextPost(blogpost) %}
 
 {% block content %}
 <main aria-label="Content">
@@ -24,29 +22,34 @@ permalink: "{{ blogpost.permalink }}index.html"
   {%- include 'blogpost.njk' -%}
 </main>
 
-<nav class="prev-next">
+{% set prevPost = posts | getPrevPost(blogpost) %}
+{% set nextPost = posts | getNextPost(blogpost) %}
+
+<nav class="blogpost-nav">
   <ol>
     {% if prevPost %}
-    <li class="prev">
-      <a href="{{ prevPost.permalink }}">
-        <span>Previous article</span>
-        <p class="entry-title previous">{{ prevPost.title | safe }}</p>
-        <time class="date" datetime="{{ prevPost.date }}">{{ prevPost.date | readableDate }}</time>
-        <svg class="arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.62 43"><defs><style>.cls-1{fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:3px;}</style></defs><polyline class="cls-1" points="22.12 1.5 2.12 21.5 22.12 41.5"></polyline></svg>
-      </a>
-    </li>
+      {% set prevPostPermalink = prevPost.permalink %}
+      {% set prevPostTitle = prevPost.title %}
+      {% set prevPostDate = prevPost.date %}
+      {% set prevPostReadableDate = prevPost.date | readableDate %}
+      {% if not nextPost %}
+      {% set prevExtraClass = ' blogpost-nav-no-next' %}
+      {% endif %}
+
+      {% include 'blogpost-nav-prev.njk' %}
     {% endif %}
+
     {% if nextPost %}
-    <li class="next">
-      <a href="{{ nextPost.permalink }}">
-        <span>Next article</span>
-        <p class="entry-title next">{{ nextPost.title | safe }}</p>
-        <time class="date" datetime="{{ nextPost.date }}">{{ nextPost.date | readableDate }}</time>
-        <svg class="arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.62 43"><defs><style>.cls-1{fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:3px;}</style></defs><polyline class="cls-1" points="1.5 1.5 21.5 21.5 1.5 41.5"></polyline></svg>
-      </a>
-    </li>
+      {% set nextPostPermalink = nextPost.permalink %}
+      {% set nextPostTitle = nextPost.title %}
+      {% set nextPostDate = nextPost.date %}
+      {% set nextPostReadableDate = nextPost.date | readableDate %}
+      {% if not prevPost %}
+      {% set nextExtraClass = ' blogpost-nav-no-prev' %}
+      {% endif %}
+
+      {% include 'blogpost-nav-next.njk' %}
     {% endif %}
   </ol>
 </nav>
-
 {% endblock content %}

--- a/src/includes/blogpost-nav-next.njk
+++ b/src/includes/blogpost-nav-next.njk
@@ -1,0 +1,11 @@
+<li class="blogpost-nav-next{{ nextExtraClass }}">
+  <a href="{{ nextPostPermalink }}">
+    <span>Next article</span>
+    <p>{{ nextPostTitle }}</p>
+    <time datetime="{{ nextPostDate }}">{{ nextPostReadableDate }}</time>
+    <svg class="blogpost-nav-arrow-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.62 43">
+      <defs><style>.cls-1{fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:3px;}</style></defs>
+      <polyline class="cls-1" points="1.5 1.5 21.5 21.5 1.5 41.5"></polyline>
+    </svg>
+  </a>
+</li>

--- a/src/includes/blogpost-nav-prev.njk
+++ b/src/includes/blogpost-nav-prev.njk
@@ -1,0 +1,11 @@
+<li class="blogpost-nav-prev{{ prevExtraClass }}">
+  <a href="{{ prevPostPermalink }}">
+    <span>Previous article</span>
+    <p>{{ prevPostTitle }}</p>
+    <time datetime="{{ prevPostDate }}">{{ prevPostReadableDate }}</time>
+    <svg class="blogpost-nav-arrow-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 23.62 43">
+      <defs><style>.cls-1{fill:none;stroke:#000;stroke-linecap:round;stroke-miterlimit:10;stroke-width:3px;}</style></defs>
+      <polyline class="cls-1" points="22.12 1.5 2.12 21.5 22.12 41.5"></polyline>
+    </svg>
+  </a>
+</li>

--- a/src/wp-content/blogposts.njk
+++ b/src/wp-content/blogposts.njk
@@ -11,8 +11,8 @@ config:
 {% set featuredImage = "<?= get_the_post_thumbnail_url(get_the_id(), 'full') ?>" | safe %}
 
 {% block content %}
+<?php while (have_posts()) : the_post(); ?>
 <main aria-label="Content">
-  <?php while (have_posts()) : the_post(); ?>
     {# The format used below is equivalent to the following Luxon format: LLLL d, kkkk #}
     {%- set postModifiedDate = "<?= get_the_modified_date('F j, Y') ?>" | safe -%}
     {%- set postContent = "<?= get_the_content() ?>" | safe -%}
@@ -20,8 +20,35 @@ config:
     {%- set postAuthorAvatar = "<?= get_avatar_url(get_the_id(), ['size' => 96]) ?>" | safe -%}
 
     {%- include 'blogpost.njk' -%}
-  <?php endwhile; ?>
 </main>
+
+<?php $prevPost = get_previous_post(); ?>
+<?php $nextPost = get_next_post(); ?>
+
+<nav class="blogpost-nav">
+  <ol>
+    <?php if ($prevPost) : ?>
+      {% set prevPostPermalink = "<?= get_permalink($prevPost->ID) ?>" | safe %}
+      {% set prevPostTitle = "<?= get_the_title($prevPost->ID) ?>" | safe %}
+      {% set prevPostDate = "<?= get_the_time(DateTime::ISO8601, $prevPost) ?>" | safe %}
+      {% set prevPostReadableDate = "<?= get_the_time('F j, Y', $prevPost) ?>" |safe %}
+      {% set prevExtraClass = "<?= empty($nextPost) ? ' blogpost-nav-no-next' : '' ?>" | safe %}
+
+      {% include 'blogpost-nav-prev.njk' %}
+    <?php endif; ?>
+
+    <?php if ($nextPost) : ?>
+      {% set nextPostPermalink = "<?= get_permalink($nextPost->ID) ?>" | safe %}
+      {% set nextPostTitle = "<?= get_the_title($nextPost->ID) ?>" | safe %}
+      {% set nextPostDate = "<?= get_the_time(DateTime::ISO8601, $nextPost) ?>" | safe %}
+      {% set nextPostReadableDate = "<?= get_the_time('F j, Y', $nextPost) ?>" |safe %}
+      {% set nextExtraClass = "<?= empty($prevPost) ? ' blogpost-nav-no-prev' : '' ?>" | safe %}
+
+      {% include 'blogpost-nav-next.njk' %}
+    <?php endif; ?>
+  </ol>
+</nav>
+<?php endwhile; ?>
 {% endblock content %}
 
 {% block stylesheets %}

--- a/tests/php/fake-template-functions.php
+++ b/tests/php/fake-template-functions.php
@@ -79,3 +79,13 @@ function get_avatar_url($id, $args = []): string
 
     return 'some avatar url';
 }
+
+function get_previous_post()
+{
+    return null;
+}
+
+function get_next_post()
+{
+    return null;
+}


### PR DESCRIPTION
This patch introduces shared templates for the blogpost (bottom) nav. Class
names have been updated for consistency and the nav is now present in the WP
theme.

I updated the WP theme on the moz instance so you can have a look at how it looks.