### PR TITLE
Add overflow-wrap: anywhere

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -12,6 +12,7 @@
 
 * {
   box-sizing: border-box;
+  overflow-wrap: anywhere;
 }
 
 html,


### PR DESCRIPTION
This fixes an issue with long strings. See: https://addons-blog-preview-willdurand.vercel.app/blog/2021/04/13/ipsumipsumipsumipsumipsumipsumipsumipsumipsumipsum-ipsumipsumipsumipsum/

After:

<img width="1552" alt="Screen Shot 2021-04-13 at 13 24 29" src="https://user-images.githubusercontent.com/217628/114544930-96bf2b80-9c5b-11eb-8c61-ed6f2e6718a6.png">
