### PR TITLE
Add overflow-wrap: break-word for Safari

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -12,6 +12,8 @@
 
 * {
   box-sizing: border-box;
+  // This is needed for Safari, which does not support `anywhere`.
+  overflow-wrap: break-word;
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/108