### PR TITLE
Move assets/ to blog/

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Whilst the `asset-pipline` script is custom, it leverages a lot of existing libs
 
 ### Asset paths
 
-For the `asset-pipeline` script to do its thing, all you need to do is refer to all assets with a path beginning with `/assets/`. If you do that, everything else is handled for you ✨
+For the `asset-pipeline` script to do its thing, all you need to do is refer to all assets with a path beginning with `/blog/assets/`. If you do that, everything else is handled for you ✨
 
 [prettier]: https://prettier.io/
 [browsersync]: https://browsersync.io/

--- a/bin/asset-pipeline
+++ b/bin/asset-pipeline
@@ -15,6 +15,7 @@ const acorn = require('acorn');
 const walk = require('acorn-walk');
 const Url = require('url-parse');
 
+const assetsDirPrefix = '/blog/assets';
 // The dir that Eleventy builds to.
 const builtAssetDir = path.resolve(__dirname, '../build/');
 // Where we're writing to.
@@ -25,7 +26,7 @@ const binaryAssetsPattern = /\.(?:ico|jpe?g|png|tiff|webp|eot|gif|otf|ttf|woff2?
 const unHashableAssetsPattern = /(?:robots\.txt|\.html|pages\.json)$/;
 
 const defaultOptions = {
-  //assetsDirPrefix,
+  assetsDirPrefix,
   binaryAssetsPattern,
   unHashableAssetsPattern,
 };
@@ -298,7 +299,7 @@ class AssetPipeline {
 
             // This is a special case to support relative paths in CSS files.
             if (assetURL.startsWith('../')) {
-              assetURL = assetURL.replace(/^\.\./, '/assets');
+              assetURL = assetURL.replace(/^\.\./, this.opts.assetsDirPrefix);
             }
 
             if (this.hasHashedReplacementURL(assetURL, assetMap)) {

--- a/bin/build-script
+++ b/bin/build-script
@@ -12,7 +12,7 @@ const isProduction = process.env.ELEVENTY_ENV === 'production';
 
 const inputFiles = ['src/assets/js/new-tab-links.js'];
 
-const outputFile = './build/assets/js/bundle.js';
+const outputFile = './build/blog/assets/js/bundle.js';
 
 const buildJS = async function () {
   const data = [];

--- a/bin/build-styles
+++ b/bin/build-styles
@@ -7,7 +7,7 @@ const sass = require('node-sass');
 
 const renderSass = util.promisify(sass.render);
 const inputFile = './src/assets/css/styles.scss';
-const outputFile = './build/assets/css/styles.css';
+const outputFile = './build/blog/assets/css/styles.css';
 const isProduction = process.env.ELEVENTY_ENV === 'production';
 
 const buildSass = async function () {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -66,8 +66,9 @@ module.exports = function configure(eleventyConfig) {
   if (process.env.NODE_ENV !== 'test') {
     // Explicitly copy through the built files needed.
     eleventyConfig.addPassthroughCopy({
-      './src/assets/img/': 'assets/img/',
-      './src/assets/fonts/': 'assets/fonts/',
+      './src/assets/img/': 'blog/assets/img/',
+      './src/assets/fonts/otf': 'blog/assets/fonts/otf',
+      './src/assets/fonts/woff2': 'blog/assets/fonts/woff2',
     });
 
     if (buildWordpressTheme) {
@@ -75,15 +76,21 @@ module.exports = function configure(eleventyConfig) {
 
       eleventyConfig.addPassthroughCopy({
         [`${wpInputDir}/screenshot.png`]: 'screenshot.png',
-        // These assets are used to build static add-on cards in WordPress.
-        [`${wpInputDir}/addon-cards.js`]: 'assets/js/addon-cards.js',
-        [`${blogUtils}/web.js`]: 'assets/js/addons-frontend-blog-utils.js',
-        [`${blogUtils}/style.css`]: 'assets/css/addons-frontend-blog-utils.css',
+        // These blog/assets are used to build static add-on cards in WordPress.
+        [`${wpInputDir}/addon-cards.js`]: 'blog/assets/js/addon-cards.js',
+        [`${blogUtils}/web.js`]: 'blog/assets/js/addons-frontend-blog-utils.js',
+        [`${blogUtils}/style.css`]: 'blog/assets/css/addons-frontend-blog-utils.css',
       });
     } else {
       eleventyConfig.addPassthroughCopy({
-        './src/content/robots.txt': 'robots.txt',
+        './src/content/robots.txt': 'blog/robots.txt',
       });
+      // We want to copy the same file twice but it isn't possible, see:
+      // https://github.com/11ty/eleventy/issues/924
+      fs.copySync(
+        './src/content/robots.txt',
+        path.join(outputDir, 'robots.txt')
+      );
     }
 
     let browserSyncConfig = {

--- a/src/layouts/base.njk
+++ b/src/layouts/base.njk
@@ -8,15 +8,15 @@
 
     {{ blogpost.seoHead | safe({ isHeadMarkup: true }) }}
 
-    <link rel="apple-touch-icon" href="{{ config.asset_path|safe }}/assets/img/favicon.png">
-    <link rel="shortcut icon" href="{{ config.asset_path|safe }}/assets/img/favicon.ico">
+    <link rel="apple-touch-icon" href="{{ config.asset_path | safe }}/blog/assets/img/favicon.png">
+    <link rel="shortcut icon" href="{{ config.asset_path | safe }}/blog/assets/img/favicon.ico">
 
     {%- if not config.no_atom_feed %}
     <link rel="alternate" type="application/atom+xml" title="{{ markup.siteTitle }} RSS Feed" href="/blog/feed.xml">
     {%- endif %}
 
     {% block stylesheets %}
-    <link rel="stylesheet" href="{{ config.asset_path|safe }}/assets/css/styles.css">
+    <link rel="stylesheet" href="{{ config.asset_path | safe }}/blog/assets/css/styles.css">
     {%- endblock %}
   </head>
   <body>
@@ -47,7 +47,7 @@
     {{ markup.footer | safe }}
 
     {% block javascripts %}
-    <script src="{{ config.asset_path|safe }}/assets/js/bundle.js"></script>
+    <script src="{{ config.asset_path | safe }}/blog/assets/js/bundle.js"></script>
     {% endblock %}
   </body>
 </html>

--- a/src/wp-content/blogposts.njk
+++ b/src/wp-content/blogposts.njk
@@ -53,11 +53,11 @@ config:
 
 {% block stylesheets %}
 {{ super() }}
-<link rel="stylesheet" href="{{ config.asset_path|safe }}/assets/css/addons-frontend-blog-utils.css">
+<link rel="stylesheet" href="{{ config.asset_path | safe }}/blog/assets/css/addons-frontend-blog-utils.css">
 {% endblock %}
 
 {% block javascripts %}
 {{ super() }}
-<script src="{{ config.asset_path|safe }}/assets/js/addons-frontend-blog-utils.js"></script>
-<script src="{{ config.asset_path|safe }}/assets/js/addon-cards.js"></script>
+<script src="{{ config.asset_path | safe }}/blog/assets/js/addons-frontend-blog-utils.js"></script>
+<script src="{{ config.asset_path | safe }}/blog/assets/js/addon-cards.js"></script>
 {% endblock %}

--- a/tests/assets-pipeline.test.js
+++ b/tests/assets-pipeline.test.js
@@ -12,7 +12,7 @@ let ap;
 describe(__filename, () => {
   describe('Asset Pipeline functions', () => {
     beforeEach(async () => {
-      ap = new AssetPipeline(src, dest);
+      ap = new AssetPipeline(src, dest, { assetsDirPrefix: '/assets' });
       await ap.recursiveListDir();
     });
 
@@ -205,7 +205,7 @@ describe(__filename, () => {
     describe('cachebustAssets', () => {
       beforeAll(async () => {
         jest.spyOn(console, 'log').mockImplementation(jest.fn());
-        ap = new AssetPipeline(src, dest);
+        ap = new AssetPipeline(src, dest, { assetsDirPrefix: '/assets' });
         await ap.cacheBustAssets();
       });
 

--- a/tests/php/WordPressThemeTest.php
+++ b/tests/php/WordPressThemeTest.php
@@ -42,7 +42,7 @@ final class WordPressThemeTest extends DOMTestCase
         $this->assertSelectEquals('.author', 'some author', 1, $html);
         $this->assertSelectCount('.Footer', 1, $html);
         $this->assertStringContainsString(
-            'src="/path/to/template/dir/assets/js/bundle.js',
+            'src="/path/to/template/dir/blog/assets/js/bundle.js',
             $html
         );
         $this->assertStringNotContainsString('application/atom+xml', $html);
@@ -65,7 +65,7 @@ final class WordPressThemeTest extends DOMTestCase
         );
         $this->assertSelectCount('.Footer', 1, $html);
         $this->assertStringContainsString(
-            'src="/path/to/template/dir/assets/js/bundle.js',
+            'src="/path/to/template/dir/blog/assets/js/bundle.js',
             $html
         );
         $this->assertStringNotContainsString('application/atom+xml', $html);


### PR DESCRIPTION
This is needed to be able to deploy the blog correctly (see #83), which essentially means pushing the content of `dist/blog/` instead of `dist/`, which contains unwanted files (like 404, fake index page, etc.). The changes are backward-compatible:

- the WP theme works as before but contains a `blog/assets/` dir instead of `assets/` (not a big deal)
- the local dev (`yarn start`) is exactly as before
- the production build works, too (asset pipeline OK)