### PR TITLE
Update CSP

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -43,7 +43,7 @@ CSP="\"content-security-policy\": \"default-src 'none'; "\
 "font-src 'self'; "\
 "form-action 'none'; "\
 "frame-ancestors 'none'; "\
-"img-src 'self'; "\
+"img-src 'self' data: https://addons.cdn.mozilla.net/user-media/ https://mozamo.wpengine.com/wp-content/ https://secure.gravatar.com; "\
 "object-src 'none'; "\
 "script-src 'self' https://www.google-analytics.com/analytics.js; "\
 "style-src 'self' 'unsafe-inline'\""


### PR DESCRIPTION
Fixes #60

---

I used the Laboratory extension to double-check the CSP and I noticed that the `img-src` needed some more values.

Here is the new config:

```
default-src 'none'; base-uri 'self'; connect-src 'self' https://www.google-analytics.com/; font-src 'self'; form-action 'none'; frame-ancestors 'none'; img-src 'self' data: https://addons.cdn.mozilla.net/user-media/ https://mozamo.wpengine.com/wp-content/ https://secure.gravatar.com; object-src 'none'; script-src 'self' https://www.google-analytics.com/analytics.js; style-src 'self' 'unsafe-inline'
```