### PR TITLE
Add dynamic-addon-cards script

### DIFF
--- a/bin/asset-pipeline
+++ b/bin/asset-pipeline
@@ -162,7 +162,7 @@ class AssetPipeline {
 
   async rewriteJS(origPath, key, assetMap = this.assetMap) {
     let code = await fs.readFile(origPath, 'utf8');
-    const ast = acorn.parse(code, { ecmaVersion: 6 });
+    const ast = acorn.parse(code, { ecmaVersion: 8 }); // 2017
     const pathNodes = [];
     const self = this;
     walk.simple(ast, {

--- a/bin/build-script
+++ b/bin/build-script
@@ -3,14 +3,16 @@
 /*
  * This script concatenates all the JS files listed below.
  * Minification is run for production builds separately
- *
  */
 
 const fetch = require('node-fetch');
 const fs = require('fs-extra');
 const isProduction = process.env.ELEVENTY_ENV === 'production';
 
-const inputFiles = ['src/assets/js/new-tab-links.js'];
+const inputFiles = [
+  'src/assets/js/new-tab-links.js',
+  'src/assets/js/dynamic-addon-cards.js',
+];
 
 const outputFile = './build/blog/assets/js/bundle.js';
 

--- a/src/assets/js/dynamic-addon-cards.js
+++ b/src/assets/js/dynamic-addon-cards.js
@@ -1,0 +1,45 @@
+/* eslint no-console: 0 */
+/* global document, fetch */
+(function dynamicAddonCards() {
+  const AMO_BASE_URL = 'https://addons.mozilla.org';
+
+  // `StaticAddonCard` elements can be marked as unavailable by adding a
+  // special CSS class. The style as well as the content is already embedded.
+  const convertToUnavailableCard = (card) => {
+    card.classList.add('StaticAddonCard--is-unavailable');
+  };
+
+  const updateAddonCard = async (card) => {
+    const { addonId } = card.dataset;
+
+    try {
+      if (!addonId) {
+        throw new Error('addonId is missing');
+      }
+
+      // TODO: use UAParser to find the right `clientApp` (either `firefox` or
+      // `android`).
+      const clientApp = 'firefox';
+
+      const response = await fetch(
+        `${AMO_BASE_URL}/api/v5/addons/addon/${addonId}/?lang=en-US&app=${clientApp}`
+      );
+
+      if (!response.ok) {
+        throw new Error('add-on not found');
+      }
+    } catch (e) {
+      console.debug(`Error caught for addonId=${addonId}: ${e.message}`);
+      convertToUnavailableCard(card);
+    }
+  };
+
+  if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
+    module.exports = {
+      convertToUnavailableCard,
+      updateAddonCard,
+    };
+  } else {
+    document.querySelectorAll('.StaticAddonCard').forEach(updateAddonCard);
+  }
+})();

--- a/tests/assets/dynamic-addon-cards.test.js
+++ b/tests/assets/dynamic-addon-cards.test.js
@@ -1,0 +1,80 @@
+/* global document */
+const { buildStaticAddonCard } = require('addons-frontend-blog-utils');
+
+const {
+  convertToUnavailableCard,
+  updateAddonCard,
+} = require('../../src/assets/js/dynamic-addon-cards');
+const tabbyAddon = require('../fixtures/amo-api-response-tabby');
+
+describe(__filename, () => {
+  const mockFetch = ({ ok = true, jsonData = {} } = {}) => {
+    return jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok,
+      json: jest.fn().mockResolvedValue(jsonData),
+    });
+  };
+
+  // The code we want to test in this file requires some HTML with static
+  // add-on cards. We can reuse the code that we are using at build time here,
+  // except that we mock the API call to generate a static add-on card in a
+  // predictable manner.
+  const loadStaticAddonCardInDocument = async ({ addon = tabbyAddon } = {}) => {
+    const fetch = mockFetch({ jsonData: addon });
+    const staticCard = await buildStaticAddonCard({ addonId: addon.id });
+    fetch.mockRestore();
+
+    document.body.innerHTML = `<div>${staticCard}</div>`;
+
+    return document.querySelector('.StaticAddonCard');
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('convertToUnavailableCard', () => {
+    it('changes the state of a card to "unavailable"', async () => {
+      const card = await loadStaticAddonCardInDocument();
+      expect(card.classList).not.toContain('StaticAddonCard--is-unavailable');
+
+      convertToUnavailableCard(card);
+
+      expect(card.classList).toContain('StaticAddonCard--is-unavailable');
+    });
+  });
+
+  describe('updateAddonCard', () => {
+    it('calls the AMO API', async () => {
+      const addon = { ...tabbyAddon };
+      const card = await loadStaticAddonCardInDocument({ addon });
+      const fetch = mockFetch({ jsonData: addon });
+
+      await updateAddonCard(card);
+
+      expect(fetch).toHaveBeenCalledWith(
+        `https://addons.mozilla.org/api/v5/addons/addon/${addon.id}/?lang=en-US&app=firefox`
+      );
+    });
+
+    it('changes the state of a card to "unavailable" when the addonId is missing', async () => {
+      const card = await loadStaticAddonCardInDocument();
+      delete card.dataset.addonId;
+      const fetch = mockFetch();
+
+      await updateAddonCard(card);
+
+      expect(fetch).not.toHaveBeenCalled();
+      expect(card.classList).toContain('StaticAddonCard--is-unavailable');
+    });
+
+    it('changes the state of a card to "unavailable" when the response is not OK', async () => {
+      const card = await loadStaticAddonCardInDocument();
+      mockFetch({ ok: false });
+
+      await updateAddonCard(card);
+
+      expect(card.classList).toContain('StaticAddonCard--is-unavailable');
+    });
+  });
+});

--- a/tests/fixtures/amo-api-response-tabby.json
+++ b/tests/fixtures/amo-api-response-tabby.json
@@ -1,0 +1,118 @@
+{
+  "id": 502774,
+  "authors": [
+    {
+      "id": 10640485,
+      "name": "<code>[Lexa-Dev]</code>",
+      "url": "https://addons-dev.allizom.org/en-US/firefox/user/10640485/",
+      "username": "LexaSV",
+      "picture_url": "https://addons-dev-cdn.allizom.org/user-media/userpics/10/10640/10640485.png?modified=1616406955"
+    }
+  ],
+  "average_daily_users": 0,
+  "categories": {
+    "android": [
+      "feeds-news-blogging"
+    ],
+    "firefox": [
+      "feeds-news-blogging"
+    ]
+  },
+  "contributions_url": "",
+  "created": "2018-12-04T09:54:24Z",
+  "current_version": {
+    "id": 1688307,
+    "compatibility": {
+      "firefox": {
+        "min": "48.0",
+        "max": "*"
+      },
+      "android": {
+        "min": "48.0",
+        "max": "*"
+      }
+    },
+    "edit_url": "https://addons-dev.allizom.org/en-US/developers/addon/tabby-catextension/versions/1688307",
+    "files": [
+      {
+        "id": 408968,
+        "created": "2019-06-14T13:26:48Z",
+        "hash": "sha256:77d8171f6d9fc1db57ee3d2ad5e4daee99f3b9148d0ac5ebcc518d2dbe51c511",
+        "is_restart_required": false,
+        "is_webextension": true,
+        "is_mozilla_signed_extension": false,
+        "platform": "all",
+        "size": 295590,
+        "status": "public",
+        "url": "https://addons-dev.allizom.org/firefox/downloads/file/408968/tabby_cat-1.0.2-an+fx.xpi",
+        "permissions": [],
+        "optional_permissions": []
+      }
+    ],
+    "is_strict_compatibility_enabled": false,
+    "license": {
+      "id": 4078,
+      "is_custom": true,
+      "name": {
+        "en-US": "Itzy Bitzy Spider"
+      },
+      "url": "https://addons-dev.allizom.org/en-US/firefox/addon/tabby-catextension/license/1.0.2"
+    },
+    "release_notes": null,
+    "reviewed": null,
+    "version": "1.0.2"
+  },
+  "default_locale": "en-US",
+  "description": {
+    "de": "Tabby cat - Katzen sind fantastisch",
+    "en-US": "Testing search again"
+  },
+  "developer_comments": null,
+  "edit_url": "https://addons-dev.allizom.org/en-US/developers/addon/tabby-catextension/edit",
+  "guid": "{1ed4b641-bac7-4492-b304-6ddc01f538ae}",
+  "has_eula": true,
+  "has_privacy_policy": true,
+  "homepage": null,
+  "icon_url": "https://addons-dev-cdn.allizom.org/user-media/addon_icons/502/502774-64.png?modified=f289a992",
+  "icons": {
+    "32": "https://addons-dev-cdn.allizom.org/user-media/addon_icons/502/502774-32.png?modified=f289a992",
+    "64": "https://addons-dev-cdn.allizom.org/user-media/addon_icons/502/502774-64.png?modified=f289a992",
+    "128": "https://addons-dev-cdn.allizom.org/user-media/addon_icons/502/502774-128.png?modified=f289a992"
+  },
+  "is_disabled": false,
+  "is_experimental": false,
+  "last_updated": "2019-06-14T13:32:46Z",
+  "name": {
+    "de": "Tabby cat - Katzen sind fantastisch",
+    "en-US": "tabby cat"
+  },
+  "previews": [],
+  "promoted": {
+    "apps": [
+      "firefox"
+    ],
+    "category": "recommended"
+  },
+  "ratings": {
+    "average": 4.5,
+    "bayesian_average": 4.359503454586003,
+    "count": 2,
+    "text_count": 2
+  },
+  "ratings_url": "https://addons-dev.allizom.org/en-US/firefox/addon/tabby-catextension/reviews/",
+  "requires_payment": false,
+  "review_url": "https://addons-dev.allizom.org/en-US/reviewers/review/502774",
+  "slug": "tabby-catextension",
+  "status": "public",
+  "summary": {
+    "de": "German tabby",
+    "en-US": "tabby cattabby cattabby cattabby cattabby cat"
+  },
+  "support_email": null,
+  "support_url": null,
+  "tags": [],
+  "type": "extension",
+  "url": "https://addons-dev.allizom.org/en-US/firefox/addon/tabby-catextension/",
+  "versions_url": "https://addons-dev.allizom.org/en-US/firefox/addon/tabby-catextension/versions/",
+  "weekly_downloads": 0
+}


### PR DESCRIPTION
refs #52 

Fixes https://github.com/mozilla/addons-blog/issues/134

---

This is the starting point of the client js we need for the blog, with tests. The only "feature" right now is to change the style of the card when the add-on is no longer available.

For the testing part, I tried to come up with a small abstraction layer to write test cases in an expressive manner. It's using the code that we use at build time to generate static cards that will be modified later by the script added in this PR. In addition to not have to write and maintain too much HTML in the tests, it will allow us to potentially catch issues if the `blog-utils` library is updated.

Once this lands, we'll be able to iterate on this script to add new features such as compatibility checks, mozAddonManager support, etc.