### PR TITLE
Fix header on small screens, update some style (UX feedback)

### DIFF
--- a/src/assets/css/blog.scss
+++ b/src/assets/css/blog.scss
@@ -9,7 +9,7 @@ $title-color: #291c48;
 $date-color: #54556b;
 $date-font-size: 12px;
 
-$excerpt-margin: 13px;
+$excerpt-margin: 14px;
 
 .blog-entries {
   display: grid;
@@ -28,7 +28,7 @@ $excerpt-margin: 13px;
 }
 
 .blog-entry {
-  margin-bottom: 13px;
+  margin-bottom: 14px;
 }
 
 .blog-entry-featured-image {

--- a/src/assets/css/blogposts.scss
+++ b/src/assets/css/blogposts.scss
@@ -52,8 +52,10 @@ $pull-quote-color: #4e1a6a;
     line-height: $heading-xxs-line-height;
   }
 
-  li {
-    margin: $default-margin 0;
+  li,
+  ul,
+  p {
+    margin: 14px 0;
   }
 
   img {
@@ -68,6 +70,10 @@ $pull-quote-color: #4e1a6a;
     &:not(.Button) {
       color: $link-color;
     }
+  }
+
+  figcaption {
+    text-align: center;
   }
 
   .wp-block-pullquote {

--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -16,8 +16,11 @@
 }
 
 .header-wrapper {
+  align-items: center;
+  display: grid;
+  grid-template-columns: auto;
+  grid-template-rows: 92px auto;
   height: 100%;
-  padding-top: 44px;
 }
 
 .header-logo {
@@ -25,9 +28,8 @@
   $aspectRatio: 4.3125;
   $smallHeight: 48px;
   $smallWidth: $smallHeight * $aspectRatio;
-  $largeHeight: 64px;
-  $largeWidth: $largeHeight * $aspectRatio;
 
+  align-self: end;
   // Important: we use a relative path in order to ease the process of building
   // the WordPress theme, and we cannot use the `/assets/` prefix in this file
   // (and other Sass files).
@@ -40,18 +42,13 @@
   width: $smallWidth;
 
   @include respond-to(l) {
-    margin-left: 48px;
-    margin-top: 0;
+    margin: 0 0 0 48px;
   }
 }
 
 .header-title {
   color: $white;
-  display: flex;
-  flex-direction: column;
-  font-size: 44px;
-  height: 60vh;
-  justify-content: center;
+  font-size: 34px;
   line-height: 1.2;
   margin: 0 auto;
   max-width: 1100px;
@@ -59,13 +56,18 @@
   text-transform: uppercase;
   width: 70%;
 
+  @include respond-to(m-height) {
+    font-size: 44px;
+    width: 90%;
+  }
+
   @include respond-to(l) {
     font-size: 54px;
-    width: 90%;
   }
 
   @include respond-to(xxl) {
     font-size: 72px;
+    margin-top: -16px;
     width: 100%;
   }
 }

--- a/src/assets/css/inc/variables.scss
+++ b/src/assets/css/inc/variables.scss
@@ -11,16 +11,16 @@ $default-margin: $default-padding;
 $max-content-width: 1366px;
 
 // See: https://mozilla.design/firefox/typography/
-$body-sm-font-size: 14px;
-$body-sm-line-height: 22px;
+$body-sm-font-size: 16px;
+$body-sm-line-height: 1.5;
 $heading-xxs-font-size: 20px;
-$heading-xxs-line-height: 24px;
+$heading-xxs-line-height: 1.2;
 $heading-xs-font-size: 24px;
-$heading-xs-line-height: 28px;
+$heading-xs-line-height: 1.16;
 $heading-sm-font-size: 32px;
-$heading-sm-line-height: 36px;
+$heading-sm-line-height: 1.125;
 $heading-md-font-size: 40px;
-$heading-md-line-height: 44px;
+$heading-md-line-height: 1.1;
 
 // No "small" breakpoint is defined here because we are mobile-first.
 //
@@ -30,6 +30,14 @@ $breakpoints: (
   m: only screen and
     (
       min-width: 500px,
+    ),
+  m-height: only screen and
+    (
+      min-width: 500px,
+    )
+    and
+    (
+      min-height: 500px,
     ),
   l: only screen and
     (

--- a/src/assets/css/inc/variables.scss
+++ b/src/assets/css/inc/variables.scss
@@ -10,17 +10,18 @@ $default-margin: $default-padding;
 
 $max-content-width: 1366px;
 
-// See: https://mozilla.design/firefox/typography/
+// We used https://mozilla.design/firefox/typography/ as a starting point but
+// line-heights are slightly different because we want unitless values.
 $body-sm-font-size: 16px;
 $body-sm-line-height: 1.5;
 $heading-xxs-font-size: 20px;
 $heading-xxs-line-height: 1.2;
 $heading-xs-font-size: 24px;
-$heading-xs-line-height: 1.16;
+$heading-xs-line-height: 1.2;
 $heading-sm-font-size: 32px;
-$heading-sm-line-height: 1.125;
+$heading-sm-line-height: 1.2;
 $heading-md-font-size: 40px;
-$heading-md-line-height: 1.1;
+$heading-md-line-height: 1.2;
 
 // No "small" breakpoint is defined here because we are mobile-first.
 //

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -37,6 +37,10 @@ main {
   max-width: $max-content-width;
   flex: 1 0 auto;
   padding: $default-padding;
+
+  @include respond-to(l) {
+    padding: 40px $default-padding;
+  }
 }
 
 .visually-hidden {


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/132
Fixes https://github.com/mozilla/addons-blog/issues/133

I also made sure that it would look good on small/medium screens.

---

("before" screenshots in the issue)

After:

![signal-2021-04-16-103315_001](https://user-images.githubusercontent.com/217628/114997042-bf376780-9e9f-11eb-9a30-b3557552e32e.png)
![signal-2021-04-16-103315_002](https://user-images.githubusercontent.com/217628/114997052-c199c180-9e9f-11eb-8fe6-52826924190e.png)

