### PR TITLE
Use `UAParser` to set the correct `app` in the API call

### DIFF
--- a/bin/build-script
+++ b/bin/build-script
@@ -11,6 +11,7 @@ const isProduction = process.env.ELEVENTY_ENV === 'production';
 
 const inputFiles = [
   'src/assets/js/new-tab-links.js',
+  'node_modules/ua-parser-js/dist/ua-parser.min.js',
   'src/assets/js/dynamic-addon-cards.js',
 ];
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "stylelint": "^13.11.0",
     "stylelint-config-standard": "^21.0.0",
     "terser": "5.6.1",
+    "ua-parser-js": "^0.7.28",
     "url-parse": "^1.5.1"
   },
   "browserslist": [

--- a/src/assets/js/dynamic-addon-cards.js
+++ b/src/assets/js/dynamic-addon-cards.js
@@ -1,5 +1,5 @@
 /* eslint no-console: 0 */
-/* global document, fetch */
+/* global document, fetch, UAParser */
 (function dynamicAddonCards() {
   const AMO_BASE_URL = 'https://addons.mozilla.org';
 
@@ -9,7 +9,7 @@
     card.classList.add('StaticAddonCard--is-unavailable');
   };
 
-  const updateAddonCard = async (card) => {
+  const updateAddonCard = async (card, { parsedUserAgent }) => {
     const { addonId } = card.dataset;
 
     try {
@@ -17,9 +17,8 @@
         throw new Error('addonId is missing');
       }
 
-      // TODO: use UAParser to find the right `clientApp` (either `firefox` or
-      // `android`).
-      const clientApp = 'firefox';
+      const { name: osName } = parsedUserAgent.getOS();
+      const clientApp = osName === 'Android' ? 'android' : 'firefox';
 
       const response = await fetch(
         `${AMO_BASE_URL}/api/v5/addons/addon/${addonId}/?lang=en-US&app=${clientApp}`
@@ -40,6 +39,10 @@
       updateAddonCard,
     };
   } else {
-    document.querySelectorAll('.StaticAddonCard').forEach(updateAddonCard);
+    const parsedUserAgent = new UAParser();
+
+    document
+      .querySelectorAll('.StaticAddonCard')
+      .forEach((card) => updateAddonCard(card, { parsedUserAgent }));
   }
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7776,7 +7776,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-ua-parser-js@^0.7.18:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.28:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/138

---

This is needed for compatibility checks and so on in the future. I made this small patch to require `ua-parser-js` and update the tests. It will be less code to review in the next patch that will bring the compatibility checks.