### PR TITLE
Add back the missing --delete option

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -108,6 +108,7 @@ aws s3 sync \
 
 # Everything else; cache forever, because it has hashes in the filenames
 aws s3 sync \
+  --delete \
   --cache-control "max-age=${ONE_YEAR}, immutable" \
   --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \


### PR DESCRIPTION
It was accidentally removed in https://github.com/mozilla/addons-blog/pull/130.