### PR TITLE
Deploy to -stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ references:
         sudo pip install --upgrade pip
         sudo pip install --upgrade awscli
 
-  persist_build_workspace: &persist_build_workspace
+  persist_deploy_workspace: &persist_deploy_workspace
     persist_to_workspace:
       root: ./
       paths:
@@ -81,7 +81,7 @@ jobs:
             yarn script:build
             bin/asset-pipeline
 
-  build-blog:
+  build-blog-dev:
     <<: *node_prod_container
     steps:
       - checkout
@@ -89,7 +89,21 @@ jobs:
       - *run_yarn_install
       - *save_build_cache
       - run: yarn build:production
-      - *persist_build_workspace
+      - *persist_deploy_workspace
+
+  build-blog-stage:
+    <<: *node_prod_container
+    steps:
+      - checkout
+      - run:
+          name: checkout latest tag
+          command: |
+            LATEST_TAG=$(git describe --tags --abbrev=0 --match='20*.*.*-stage')
+            echo "Latest tag is: $LATEST_TAG"
+            git checkout "$LATEST_TAG"
+      - *run_yarn_install
+      - run: yarn build:production
+      - *persist_deploy_workspace
 
   deploy-dev:
     <<: *deployment_container
@@ -107,13 +121,30 @@ jobs:
             AMO_BASE_URL=https://addons-dev.allizom.org               \
             ./bin/deploy.sh
 
+  deploy-stage:
+    <<: *deployment_container
+    steps:
+      - *attach_deploy_workspace
+      - *install_aws_cli
+      - run:
+          name: addons-blog deployment (stage)
+          command: |
+            pwd && ls -l
+            AWS_ACCESS_KEY_ID="${STAGE_AWS_ACCESS_KEY_ID}"            \
+            AWS_SECRET_ACCESS_KEY="${STAGE_AWS_SECRET_ACCESS_KEY}"    \
+            ADDONS_BLOG_BUCKET="${STAGE_ADDONS_BLOG_BUCKET}"          \
+            ADDONS_BLOG_BUCKET_PREFIX="${ADDONS_BLOG_BUCKET_PREFIX}"  \
+            AMO_BASE_URL=https://addons.allizom.org                   \
+            ./bin/deploy.sh
+
 workflows:
   version: 2
   default-workflow:
     jobs:
       - test-wptheme
       - test-blog
-      - build-blog:
+      # -dev
+      - build-blog-dev:
           requires:
             - test-blog
           filters:
@@ -121,7 +152,41 @@ workflows:
               only: main
       - deploy-dev:
           requires:
-            - build-blog
+            - build-blog-dev
           filters:
             branches:
               only: main
+      # -stage
+      - build-blog-stage:
+          # Note that the tags filter is needed because "Circle CI does not
+          # run workflows for tags unless you explicitly specify tag filters.
+          # Additionally, if a job requires any other jobs (directly or
+          # indirectly), you must specify tag filters for those jobs.
+          filters:
+            tags:
+              only: /.+-stage/
+            branches:
+              ignore: /.*/
+      - deploy-stage:
+          requires:
+            - build-blog-stage
+          filters:
+            tags:
+              only: /.+-stage/
+            branches:
+              ignore: /.*/
+
+  autodeploy-stage:
+    triggers:
+      - schedule:
+          # Every 3 hours (but without `*/3` because it is NOT supported), see:
+          # https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow
+          cron: "0 0,3,6,9,12,15,18,21 * * *"
+          filters:
+            branches:
+              only: main
+    jobs:
+      - build-blog-stage
+      - deploy-stage:
+          requires:
+            - build-blog-stage

--- a/bin/build-version-json.sh
+++ b/bin/build-version-json.sh
@@ -6,9 +6,10 @@ cd $(dirname $0)/..
 HASH=$(git --no-pager log --format=format:"%H" -1)
 TAG=$(git describe --tags)
 
-printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/addons-blog"}\n' \
+printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/addons-blog","buildtime":"%s"}\n' \
     "$HASH" \
     "$TAG" \
+    "$(date --utc +%FT%T%Z)" \
     > version.json
 
 cat version.json


### PR DESCRIPTION
Fixes #148 (hopefully)

---

1. The secrets for -stage are already configured so it should work
2. I tried the build/deploy stage (without pushing to S3) in https://app.circleci.com/pipelines/github/mozilla/addons-blog/377/workflows/381b5f3b-b273-4b7f-b827-9e31c493a574
3. I don't know if the cron task is going to work, it looks like we will only know once the PR lands
4. I added a `buildtime` field in the `version.json` file because it's convenient