### PR TITLE
Fix focus styles for keyboard navigation

### DIFF
--- a/bin/build-script
+++ b/bin/build-script
@@ -12,6 +12,7 @@ const isProduction = process.env.ELEVENTY_ENV === 'production';
 // The order is this array matters (because `dynamic-addon-cards.js` depends on
 // some other scripts).
 const inputFiles = [
+  'node_modules/focus-visible/dist/focus-visible.min.js',
   'src/assets/js/setup-dropdown-menu.js',
   'src/assets/js/new-tab-links.js',
   'node_modules/ua-parser-js/dist/ua-parser.min.js',

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint": "^7.22.0",
     "eslint-config-amo": "^4.3.0",
     "flat-cache": "^3.0.4",
+    "focus-visible": "^5.2.0",
     "fs-extra": "^9.1.0",
     "jest": "^26.6.3",
     "jsdom": "^16.5.1",

--- a/src/assets/css/blog.scss
+++ b/src/assets/css/blog.scss
@@ -102,6 +102,7 @@ $excerpt-margin: 14px;
   }
 
   &:hover::after,
+  &:active::after,
   &:focus::after {
     margin-left: 4px;
   }

--- a/src/assets/css/blogpost-nav.scss
+++ b/src/assets/css/blogpost-nav.scss
@@ -15,7 +15,9 @@
     display: block;
     text-decoration: none;
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
       p {
         color: $link-color;
         text-decoration: underline;

--- a/src/assets/css/blogposts.scss
+++ b/src/assets/css/blogposts.scss
@@ -113,6 +113,7 @@ $breadcrumb-text-color: #52525e;
   a:link,
   a:visited,
   a:hover,
+  a:focus,
   a:active {
     &:not(.Button) {
       color: $link-color;

--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -39,6 +39,7 @@
   display: block;
   height: $smallHeight;
   margin: 20px auto;
+  outline-color: $white;
   width: $smallWidth;
 
   @include respond-to(l) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3017,6 +3017,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
+focus-visible@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-5.2.0.tgz#3a9e41fccf587bd25dcc2ef045508284f0a4d6b3"
+  integrity sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==
+
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/167

---

Only the "More..." link isn't fixed because it seems to be an addons-frontend issue.

I tested on Chrome and Firefox with the pref `accessibility.tabfocus` set to `7`.

Something we could improve later (maybe) is: at the bottom of a blog post, we go up to the Twitter share button before going to the navigation links.