### PR TITLE
Use 'word-break: break-word' instead of 'overflow-wrap: anywhere'

### DIFF
--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -12,9 +12,11 @@
 
 * {
   box-sizing: border-box;
-  // This is needed for Safari, which does not support `anywhere`.
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
+  // We cannot use `overflow-wrap: anywhere` because it is not supported by
+  // Safari. MDN says `word-break: break-word` "has the same effect as
+  // word-break: normal and overflow-wrap: anywhere, regardless of the actual
+  // value of the overflow-wrap property".
+  word-break: break-word;
 }
 
 html,


### PR DESCRIPTION
Fixes https://github.com/mozilla/addons-blog/issues/176

---

Sorry for the back and forth. This seems to work as we expect now, on all browsers.