### PR TITLE
Remove date in permalinks

### DIFF
--- a/src/wordpress.js
+++ b/src/wordpress.js
@@ -4,7 +4,6 @@ const path = require('path');
 
 const fetch = require('node-fetch');
 const flatcache = require('flat-cache');
-const { DateTime } = require('luxon');
 
 const AMO_BASE_URL = process.env.AMO_BASE_URL || 'https://addons.mozilla.org';
 const AMO_BLOG_BASE_URL = `${AMO_BASE_URL}/blog`;
@@ -43,9 +42,7 @@ const createPost = ({
   yoast_head,
   featured_media,
 }) => {
-  const permalink = `/blog/${DateTime.fromISO(date).toFormat(
-    'y/LL/dd'
-  )}/${slug}/`;
+  const permalink = `/blog/${slug}/`;
 
   return {
     author,

--- a/tests/wordpress.test.js
+++ b/tests/wordpress.test.js
@@ -1,5 +1,3 @@
-const { DateTime } = require('luxon');
-
 const {
   AMO_BLOG_BASE_URL,
   WORDPRESS_BASE_URL,
@@ -13,9 +11,7 @@ describe(__filename, () => {
   describe('createPost', () => {
     it('creates an internal post object', () => {
       const post = createPost(apiPost);
-      const permalink = `/blog/${DateTime.fromISO(apiPost.date).toFormat(
-        'y/LL/dd'
-      )}/${apiPost.slug}/`;
+      const permalink = `/blog/${apiPost.slug}/`;
 
       expect(post).toEqual({
         author: apiPost.author,


### PR DESCRIPTION
Fixes #218 

---

We'll need to update a setting in WP: Settings > Permalinks > (select) Post name