### PR TITLE
Add codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.02%
+    patch: off


### PR DESCRIPTION
This is the config from addons-linter, which is derived from the addons-frontend one.