### PR TITLE
Generate sitemap.xml

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -14,6 +14,7 @@ const {
   mediaGetFullURL,
   mediaGetMediumURL,
   readableDate,
+  sitemapDate,
 } = require('./src/filters');
 const { createNunjucksEnvironment } = require('./src/nunjucks');
 
@@ -59,6 +60,7 @@ module.exports = function configure(eleventyConfig) {
   eleventyConfig.addFilter('mediaGetFullURL', mediaGetFullURL);
   eleventyConfig.addFilter('mediaGetMediumURL', mediaGetMediumURL);
   eleventyConfig.addFilter('readableDate', readableDate);
+  eleventyConfig.addFilter('sitemapDate', sitemapDate);
 
   // We have integration tests that rely on a test project and it doesn't have
   // the files listed below so we don't copy those when executing the tests.

--- a/src/content/404.njk
+++ b/src/content/404.njk
@@ -6,6 +6,7 @@ useHeaderMarkup: true
 title: Page Not Found
 config:
   is_404: true
+eleventyExcludeFromCollections: true
 ---
 
 <h1>Oops! We can’t find that page</h1>

--- a/src/content/blogposts.njk
+++ b/src/content/blogposts.njk
@@ -4,6 +4,7 @@ pagination:
   size: 1
   alias: blogpost
 permalink: "{{ blogpost.permalink }}index.html"
+eleventyExcludeFromCollections: true
 ---
 
 {% extends "../layouts/base.njk" %}

--- a/src/content/feed.njk
+++ b/src/content/feed.njk
@@ -1,5 +1,6 @@
 ---
 permalink: blog/feed.xml
+eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/src/content/index.njk
+++ b/src/content/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: base.njk
 useHeaderMarkup: true
+eleventyExcludeFromCollections: true
 ---
 
 {% block content %}

--- a/src/content/sitemap.njk
+++ b/src/content/sitemap.njk
@@ -1,0 +1,24 @@
+---
+permalink: blog/sitemap.xml
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {# First, we add _all_ the non-blogpost pages that are not excluded from
+     collections. #}
+  {%- for entry in collections.all %}
+  <url>
+    <loc>{{ markup.baseURL }}{{ entry.url }}</loc>
+    <lastmod>{{ entry.date | sitemapDate }}</lastmod>
+  </url>
+  {%- endfor %}
+  {# Then, we add the blog posts using the `posts` data collection instead of
+     the `all` collection because we want to access specific properties like
+     the `modified` date. #}
+  {%- for post in posts %}
+  <url>
+    <loc>{{ post.absolutePermalink }}</loc>
+    <lastmod>{{ post.modified | convertToJsDate | sitemapDate }}</lastmod>
+  </url>
+  {%- endfor %}
+</urlset>

--- a/src/filters.js
+++ b/src/filters.js
@@ -149,6 +149,10 @@ const readableDate = (value) => {
   return DateTime.fromISO(value).toFormat('LLLL d, kkkk');
 };
 
+const sitemapDate = (value) => {
+  return DateTime.fromJSDate(value).toISODate();
+};
+
 const getPost = (allPosts, currentPost, modifier) => {
   let postIndex;
   for (let i = 0; i < allPosts.length; i++) {
@@ -194,4 +198,5 @@ module.exports = {
   mediaGetFullURL,
   mediaGetMediumURL,
   readableDate,
+  sitemapDate,
 };

--- a/tests/content/sitemap.test.js
+++ b/tests/content/sitemap.test.js
@@ -1,0 +1,59 @@
+const path = require('path');
+
+const { createNunjucksEnvironment } = require('../../src/nunjucks');
+const { createPost } = require('../../src/wordpress');
+const { convertToJsDate, sitemapDate } = require('../../src/filters');
+const apiPost = require('../fixtures/apiPost');
+
+describe(__filename, () => {
+  const nunjucksEnvironment = createNunjucksEnvironment({
+    searchPaths: [path.resolve(path.join(__dirname, '..', '..'))],
+  });
+  nunjucksEnvironment.addFilter('convertToJsDate', convertToJsDate);
+  nunjucksEnvironment.addFilter('sitemapDate', sitemapDate);
+
+  it('renders a sitemap', async () => {
+    const post = createPost({ ...apiPost });
+    const entry = { url: '/blog/', date: new Date() };
+
+    const sitemap = await new Promise((res, rej) => {
+      nunjucksEnvironment.render(
+        'src/content/sitemap.njk',
+        {
+          collections: {
+            all: [entry],
+          },
+          posts: [post],
+        },
+        (err, output) => {
+          if (err) {
+            rej(err);
+          }
+
+          res(output);
+        }
+      );
+    });
+
+    expect(sitemap).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">'
+    );
+    expect(sitemap.match(/<url>/g)).toHaveLength(2);
+    expect(sitemap).toContain(
+      [
+        '  <url>',
+        `    <loc>${entry.url}</loc>`,
+        `    <lastmod>${sitemapDate(entry.date)}</lastmod>`,
+        '  </url>',
+      ].join('\n')
+    );
+    expect(sitemap).toContain(
+      [
+        '  <url>',
+        `    <loc>${post.absolutePermalink}</loc>`,
+        `    <lastmod>${sitemapDate(convertToJsDate(post.modified))}</lastmod>`,
+        '  </url>',
+      ].join('\n')
+    );
+  });
+});

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -9,6 +9,7 @@ const {
   mediaGetFullURL,
   mediaGetMediumURL,
   readableDate,
+  sitemapDate,
 } = require('../src/filters');
 const apiPost = require('./fixtures/apiPost');
 
@@ -498,6 +499,15 @@ describe(__filename, () => {
       it('returns null when there is no next post', () => {
         expect(getNextPost(allPosts, allPosts[3])).toEqual(null);
       });
+    });
+  });
+
+  describe('sitemapDate', () => {
+    it('formats a JS date for the sitemap "lastmod" tag', () => {
+      // JS date "month" starts at 0.
+      const jsDate = new Date(2021, 2, 1);
+
+      expect(sitemapDate(jsDate)).toEqual('2021-03-01');
     });
   });
 });


### PR DESCRIPTION
Fixes #204 

---

This should generate the following file and content:

```
$ cat build/blog/sitemap.xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
  
  <url>
    <loc>https://addons.mozilla.org/blog/</loc>
    <lastmod>2021-04-15</lastmod>
  </url>
  
  <url>
    <loc>https://addons.mozilla.org/blog/the-best-adblockers-for-firefox-2/</loc>
    <lastmod>2021-06-14</lastmod>
  </url>
  <url>
    <loc>https://addons.mozilla.org/blog/best-adblockers-firefox-2021/</loc>
    <lastmod>2021-06-11</lastmod>
  </url>
</urlset>
```