### PR TITLE
Remove underline from headers that are also links

### DIFF
--- a/src/assets/css/blogposts.scss
+++ b/src/assets/css/blogposts.scss
@@ -76,6 +76,15 @@ $breadcrumb-text-color: #52525e;
     margin-top: 0;
   }
 
+  h2,
+  h3,
+  h4,
+  h5 {
+    a {
+      text-decoration: none;
+    }
+  }
+
   h2 {
     font-size: $heading-md-font-size;
     line-height: $heading-md-line-height;


### PR DESCRIPTION
Fixes #241

---

Before:

![](https://user-images.githubusercontent.com/217628/122190107-d12e8a00-ce91-11eb-9b00-62ba6cf108ee.png)

After:

![Screenshot 2021-06-16 at 11 02 48](https://user-images.githubusercontent.com/217628/122190958-97aa4e80-ce92-11eb-983e-6e2a788a1aa8.png)
