### PR TITLE
Fix title size on small-ish screens

### DIFF
--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -58,7 +58,6 @@
   width: 70%;
 
   @include respond-to(m-height) {
-    font-size: 44px;
     width: 90%;
   }
 

--- a/src/assets/css/header.scss
+++ b/src/assets/css/header.scss
@@ -49,7 +49,7 @@
 
 .header-title {
   color: $white;
-  font-size: 34px;
+  font-size: 5vh;
   line-height: 1.2;
   margin: 0 auto;
   max-width: 1100px;


### PR DESCRIPTION
Fixes #262

---

Editorial uses rather long titles so we need to reduce the font-size a bit on small-ish screens to avoid the titles to be "cut" (= hidden behind the actual content). ~~I haven't found an easy way to adjust the font size automatically (e.g., depending on the screen height), in part because the "header" is already dynamically adjusted according to the screen height. This change looks good on most screens so I think we're good.~~ => Switched to `vh`

Note: this isn't reproducible on all small screens but that's a problem on my mobile device.

## Screenshot

Before:

![Screen Shot 2021-07-16 at 10 52 42](https://user-images.githubusercontent.com/217628/125921460-221da35c-652b-415d-8143-9d4e8bb4c010.png)

After:

![Screen Shot 2021-07-16 at 10 52 34](https://user-images.githubusercontent.com/217628/125921473-b8fa2f49-3dea-400e-92b8-4167e738f270.png)
