### PR TITLE
Configure short cache for XML files

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -117,6 +117,17 @@ aws s3 sync \
   --acl "public-read" \
   "$src_dir"/ s3://${ADDONS_BLOG_BUCKET}/
 
+# XML; short cache
+aws s3 sync \
+  --cache-control "max-age=${TEN_MINUTES}" \
+  --content-type "application/xml" \
+  --exclude "*" \
+  --include "*.xml" \
+  --metadata "{${ACAO}, ${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  "$src_dir"/ s3://${ADDONS_BLOG_BUCKET}/
+
 # SVG; cache forever, assign correct content-type
 aws s3 sync \
   --cache-control "max-age=${ONE_YEAR}, immutable" \

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -123,7 +123,7 @@ aws s3 sync \
   --content-type "application/xml" \
   --exclude "*" \
   --include "*.xml" \
-  --metadata "{${ACAO}, ${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
+  --metadata "{${CSPSTATIC}, ${HSTS}, ${TYPE}, ${XSS}, ${XFRAME}, ${REFERRER}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   "$src_dir"/ s3://${ADDONS_BLOG_BUCKET}/


### PR DESCRIPTION
Fixes #270

---

This is needed because feed/sitemap XML files aren't hashed.