### PR TITLE
Replace 'display: inline-block' where it breaks on Safari

### DIFF
--- a/src/assets/css/blogposts.scss
+++ b/src/assets/css/blogposts.scss
@@ -23,7 +23,7 @@ $breadcrumb-text-color: #52525e;
     padding: 0;
 
     li {
-      display: inline-block;
+      display: inline;
       list-style-type: none;
     }
 
@@ -227,6 +227,7 @@ $breadcrumb-text-color: #52525e;
     background: #1da1f2 url('../img/twitter.svg') 6px center no-repeat;
     border-color: #0d95e8;
     color: $white;
+    margin-right: 5px;
 
     &:hover,
     &:focus,
@@ -253,8 +254,8 @@ $breadcrumb-text-color: #52525e;
     border-radius: 0;
     border-style: solid;
     border-width: 1px;
-    display: inline-block;
-    padding: 1px 5px 1px 25px;
+    display: inline;
+    padding: 3px 5px 3px 25px;
     position: relative;
     text-align: center;
     text-decoration: none;


### PR DESCRIPTION
Fixes #272

---

It looks like `display: inline-block` is behaving differently on Safari versus all other browsers. This PR updates the SCSS to display the same UI with `display: inline`.

## Screenshots