### PR TITLE
Set the right tag in version.json

### DIFF
--- a/bin/build-version-json.sh
+++ b/bin/build-version-json.sh
@@ -4,7 +4,15 @@ echo "$(dirname $0)"
 cd $(dirname $0)/..
 
 HASH=$(git --no-pager log --format=format:"%H" -1)
-TAG=$(git describe --tags)
+
+if [ "$AMO_BASE_URL" == "https://addons.mozilla.org" ]; then
+    TAG=$(git describe --tags --abbrev=0 --match='20*.*.*')
+elif [ "$AMO_BASE_URL" == "https://addons.allizom.org" ]; then
+    TAG=$(git describe --tags --abbrev=0 --match='20*.*.*-stage')
+else
+    # No tag on -dev
+    TAG=""
+fi
 
 printf '{"commit":"%s","version":"%s","source":"https://github.com/mozilla/addons-blog","buildtime":"%s"}\n' \
     "$HASH" \


### PR DESCRIPTION
Fixes #277

---

We use `$AMO_BASE_URL` to determine the environment because it is already set in the Circle configuration. The command to read the tag is almost always the same, only the pattern is different (for -prod, it looks like git will choose the shortest tag, which is why we don't need to exclude the `-stage` suffix but we'll see...). For -dev, the tag is now empty, which is what we seem to do for addons-frontend (and that kinda makes sense).