### PR TITLE
Update ua-parser-js to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "stylelint": "^13.13.0",
     "stylelint-config-standard": "^22.0.0",
     "terser": "5.9.0",
-    "ua-parser-js": "^0.7.28",
+    "ua-parser-js": "^1.0.1",
     "url-parse": "^1.5.1"
   },
   "browserslist": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,7 +5464,6 @@ photon-colors@^3.3.2:
 
 php-parser@glayzzle/php-parser#4c5b0675f52c0baab2e5b10a4e50e5d7a79b2767:
   version "3.0.2"
-  uid "4c5b0675f52c0baab2e5b10a4e50e5d7a79b2767"
   resolved "https://codeload.github.com/glayzzle/php-parser/tar.gz/4c5b0675f52c0baab2e5b10a4e50e5d7a79b2767"
 
 picocolors@^0.2.1:
@@ -7224,6 +7223,11 @@ ua-parser-js@^0.7.28:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"
   integrity sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==
+
+ua-parser-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.1.tgz#268408f4d60375e67aa919fa7d117bdc66d5cd77"
+  integrity sha512-ZMu7XRN3M3R+g/YaFQKiVW0J42bzciF0+xAxP5uuO6VibE30MQvRRBctHuh22uS3yAe5jkru/i8QVOwRDJazIw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This patch sets the ua-parser-js version to `1.0.1` because Renovate used `1.0.0` (which does not exist but was one of the malicious versions). AFAICT `1.0.1` is the same code as `0.8.1` and `0.7.30`, which is based on `0.7.28`.