### PR TITLE
Fix GA4 dataLayer function - can't use rest params

### DIFF
--- a/src/assets/js/analytics.js
+++ b/src/assets/js/analytics.js
@@ -17,9 +17,13 @@
         window.ga(method, data);
       }
     },
-    gtag(...args) {
+    gtag() {
       if (this.isEnabled()) {
-        window.dataLayer.push(args);
+        // Google Tag Manager expects dataLayer to contain objects looking like
+        // arrays, not actual arrays (i.e. Arguments objects), we can't just
+        // use ...args rest params.
+        // eslint-disable-next-line prefer-rest-params
+        window.dataLayer.push(arguments);
       }
     },
     sendEvent({ category, action, label }) {

--- a/tests/assets/analytics.test.js
+++ b/tests/assets/analytics.test.js
@@ -42,16 +42,16 @@ describe(__filename, () => {
       // we are not passing an Array, though.
       // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
       expect(window.dataLayer.push.mock.calls[0][0]).not.toBeInstanceOf(Array);
-      expect(window.dataLayer.push.mock.calls[0][0]).toMatchObject({
-        0: 'event',
-        1: category,
-        2: {
+      expect(Array.from(window.dataLayer.push.mock.calls[0][0])).toEqual([
+        'event',
+        category,
+        {
           eventAction: action,
           eventCategory: category,
           eventLabel: label,
           hitType: 'event',
         },
-      });
+      ]);
     });
 
     it('does not send a GA event when disabled', () => {

--- a/tests/assets/analytics.test.js
+++ b/tests/assets/analytics.test.js
@@ -37,11 +37,11 @@ describe(__filename, () => {
         eventAction: action,
         eventLabel: label,
       });
-      // Ugly check but the content of the object is not the only thing that
-      // matters: pushing an array doesn't work.
-      expect(window.dataLayer.push.mock.calls[0][0].toString()).toBe(
-        '[object Arguments]'
-      );
+      // We must pass an array-like object to `dataLayer.push()` but we cannot verify
+      // that we pass an object since an Array is also an Object... We can make sure that
+      // we are not passing an Array, though.
+      // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
+      expect(window.dataLayer.push.mock.calls[0][0]).not.toBeInstanceOf(Array);
       expect(window.dataLayer.push.mock.calls[0][0]).toMatchObject({
         0: 'event',
         1: category,

--- a/tests/assets/analytics.test.js
+++ b/tests/assets/analytics.test.js
@@ -37,16 +37,21 @@ describe(__filename, () => {
         eventAction: action,
         eventLabel: label,
       });
-      expect(Array.from(window.dataLayer.push.mock.calls[0][0])).toEqual([
-        'event',
-        category,
-        {
+      // Ugly check but the content of the object is not the only thing that
+      // matters: pushing an array doesn't work.
+      expect(window.dataLayer.push.mock.calls[0][0].toString()).toBe(
+        '[object Arguments]'
+      );
+      expect(window.dataLayer.push.mock.calls[0][0]).toMatchObject({
+        0: 'event',
+        1: category,
+        2: {
           eventAction: action,
           eventCategory: category,
           eventLabel: label,
           hitType: 'event',
         },
-      ]);
+      });
     });
 
     it('does not send a GA event when disabled', () => {


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/AMO-95