### PR TITLE
Bump Node.js to 18.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
 
   node_prod_container: &node_prod_container
     docker:
-      - image: cimg/node:16.18
+      - image: cimg/node:18.18
 
   install_aws_cli: &install_aws_cli
     run:


### PR DESCRIPTION
Note: This is for the build step. The deployment step runs on `cimg/python:3.11-node` which should already be using Node 18.x

Fixes #603